### PR TITLE
reverse the order of dependency

### DIFF
--- a/lilaclib.py
+++ b/lilaclib.py
@@ -326,6 +326,7 @@ def call_build_cmd(tag, depends, pkgs_to_build=None):
     cmd = ['%s-build' % tag, '--']
 
     if depends:
+      depends = depends[::-1] # reverse the order of dependency
       for x in depends:
         cmd += ['-I', x]
 


### PR DESCRIPTION
During the build of 3 packages A, B, C, if we have A depends B and B depends C written in lilac.py, current lilac will generate a build command for A like:
```extra-x86_64-build -- -I B -I C```
which will stop with an error saying `cannot resolve "C", a dependency of "B"`.
In this case, reversing the order of dependencies as
```extra-x86_64-build -- -I C -I B```
will solve this problem.

An real example of this problem will be `awesome34`, `lua51-doc` and `lua51-logging`,
where `awesome34` depends on `lua51-doc` and `lua51-doc` depends on `lua51-logging`.
The build log of `awesome34` that complains about the problem is pasted here:
http://cfp.vim-cn.com/cbRp
