### PR TITLE
remove ansi and save the build log to lilac.log

### DIFF
--- a/lilaclib.py
+++ b/lilaclib.py
@@ -532,6 +532,15 @@ def run_cmd(cmd, *, use_pty=False, silent=False):
 
   out = b''.join(out)
   out = out.decode('utf-8', errors='replace')
+
+  if cmd[0][-6:] == '-build':
+      ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
+      out=ansi_escape.sub('', out)
+      out=re.sub(r'\r\n','\n',out)
+      out=re.sub(r'.*\r','',out)
+      log = open('lilac.log', 'w')
+      log.writelines(out)
+      log.close()
   if code != 0:
       raise CalledProcessError(code, cmd, out)
   return out


### PR DESCRIPTION
类似 #16 
方法还比较初级。。。
生成的log就在各自目录下

不过现在返回的out也是清理过的了