### PR TITLE
Add utils for editing pkgbuild (in lilac2.pkgbuild) and export api

### DIFF
--- a/lilac2/api.py
+++ b/lilac2/api.py
@@ -2,8 +2,12 @@ import logging
 import shutil
 
 from .cmd import run_cmd, git_pull, git_push
+from .pkgbuild import add_into_array, add_depends, add_makedepends
 assert git_push
 assert git_pull
+assert add_into_array
+assert add_depends
+assert add_makedepends
 
 logger = logging.getLogger(__name__)
 

--- a/lilac2/pkgbuild.py
+++ b/lilac2/pkgbuild.py
@@ -1,0 +1,37 @@
+import re
+import lilaclib
+
+def unquote_item(s):
+    m = re.search(r'''[ \t'"]*([^ '"]+)[ \t'"]*''', s)
+    if m != None:
+        return m.group(1)
+    else:
+        return None
+
+def add_into_array(line, values):
+    l = line.find('(')
+    r = line.rfind(')')
+    arr_str = line[l+1:r].strip()
+    arr = {unquote_item(x) for x in arr_str.split(' ')}.union(values)
+    arr_str = '('
+    for item in arr:
+        if item == None: continue
+        arr_str += "'{}' ".format(item)
+    arr_str += ')'
+    line = line[:l] + arr_str
+    return line
+
+def _add_deps(which, extra_deps):
+    '''
+    Add more values into the dependency array
+    '''
+    for line in lilaclib.edit_file('PKGBUILD'):
+        if line.strip().startswith(which):
+            line = add_into_array(line, extra_deps)
+        print(line)
+
+def add_depends(extra_deps):
+    _add_deps('depends', extra_deps)
+
+def add_makedepends(extra_deps):
+    _add_deps('makedepends', extra_deps)

--- a/lilaclib.py
+++ b/lilaclib.py
@@ -20,6 +20,8 @@ from lilac2 import lilacpy
 from lilac2.api import (
   run_cmd, vcs_update,
   git_push, git_pull,
+  add_into_array,
+  add_depends, add_makedepends,
 )
 assert git_push
 


### PR DESCRIPTION
依建議調整文件名，並在`lilac2.api`中import可用函數（且在`lilaclib`中再次import）

Closes #62