### PR TITLE
lilaclib: fix update_pkgrel() for pkgrel >= 10 and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pylib/
 __pycache__/
 *.sw*
+.pytest_cache/

--- a/lilaclib.py
+++ b/lilaclib.py
@@ -130,7 +130,7 @@ def update_pkgrel(rel=None):
       rel = int(float(m.group(1))) + 1
     return str(rel)
 
-  pkgbuild = re.sub(r'''(?<=^pkgrel=)['"]?([\d.])+['"]?''', replacer, pkgbuild, count=1, flags=re.MULTILINE)
+  pkgbuild = re.sub(r'''(?<=^pkgrel=)['"]?([\d.]+)['"]?''', replacer, pkgbuild, count=1, flags=re.MULTILINE)
   with open('PKGBUILD', 'w') as f:
     f.write(pkgbuild)
   logger.info('pkgrel updated to %s', rel)

--- a/test/test_lilaclib.py
+++ b/test/test_lilaclib.py
@@ -1,0 +1,32 @@
+import pathlib
+import sys
+
+import pytest
+
+# sys.path does not support `Path`s yet
+this_dir = pathlib.Path(__file__).resolve()
+sys.path.insert(0, str(this_dir.parents[1]))
+sys.path.insert(0, str(this_dir.parents[1] / 'pylib'))
+
+from lilaclib import (
+  update_pkgrel,
+)
+
+from myutils import at_dir
+
+
+@pytest.mark.parametrize('pkgbuild, expected_pkgbuild, kwargs', [
+  ('pkgrel=1', 'pkgrel=2', {}),
+  ('pkgrel=10', 'pkgrel=11', {}),
+  ('pkgrel=1.1', 'pkgrel=2', {}),
+  ('pkgrel="1"', 'pkgrel=2', {}),
+  ('pkgrel=1', 'pkgrel=3', {'rel': 3}),
+])
+def test_update_pkgrel(tmpdir, pkgbuild, expected_pkgbuild, kwargs):
+  with at_dir(tmpdir):
+    with open('PKGBUILD', 'w') as f:
+      f.write(pkgbuild)
+    update_pkgrel(**kwargs)
+    with open('PKGBUILD', 'r') as f:
+      new_pkgbuild = f.read()
+    assert new_pkgbuild == expected_pkgbuild


### PR DESCRIPTION
For example, a `PKGBUILD` with `pkgrel=10` should become `pkgrel=11` after calling `update_pkgrel()`.

The test suite uses pytest. A sample run:
```
$ py.test-3.6 -v
===================================================== test session starts ======================================================
platform darwin -- Python 3.6.5, pytest-3.5.1, py-1.5.3, pluggy-0.6.0 -- /opt/local/Library/Frameworks/Python.framework/Versions/3.6/bin/python3.6
cachedir: .pytest_cache
rootdir: /Users/yen/Projects/lilac, inifile:
collected 5 items

test/test_lilaclib.py::test_update_pkgrel[pkgrel=1-pkgrel=2-kwargs0] PASSED                                              [ 20%]
test/test_lilaclib.py::test_update_pkgrel[pkgrel=10-pkgrel=11-kwargs1] PASSED                                            [ 40%]
test/test_lilaclib.py::test_update_pkgrel[pkgrel=1.1-pkgrel=2-kwargs2] PASSED                                            [ 60%]
test/test_lilaclib.py::test_update_pkgrel[pkgrel="1"-pkgrel=2-kwargs3] PASSED                                            [ 80%]
test/test_lilaclib.py::test_update_pkgrel[pkgrel=1-pkgrel=3-kwargs4] PASSED                                              [100%]

=================================================== 5 passed in 0.22 seconds ===================================================
```