### PR TITLE
recv_gpg_keys: check keys in local keyring first

### DIFF
--- a/recv_gpg_keys
+++ b/recv_gpg_keys
@@ -3,6 +3,6 @@
 . ./PKGBUILD
 for key in ${validpgpkeys[@]}; do
   echo "Receiving key ${key}..."
-  # try twice
-  gpg --recv-keys $key || gpg --recv-keys $key
+  # first check if the key is already received; if not try it twice
+  gpg --list-keys $key || gpg --recv-keys $key || gpg --recv-keys $key
 done


### PR DESCRIPTION
build.archlinuxcn.org和GPG keyserver的通信似乎滿常失敗的...例如2018-06-25T01:17:01中，三個需要PGP key的包都打包失敗了。應該盡量使用之前接收過的key。

有一種情況需要重新接收key，就是上游的維護者增加了新的subkey，並且用那把subkey來簽名。我猜這種情況很罕見，如果真的發生了，手動把key刪除就好？