### PR TITLE
lilaclib: skipping non-existent bind-mount paths for the container

### DIFF
--- a/lilaclib.py
+++ b/lilaclib.py
@@ -360,6 +360,13 @@ def call_build_cmd(tag, depends, bindmounts=(), makechrootpkg_args=[]):
 
     if bindmounts:
       for x in bindmounts:
+        # Skipping non-existent source paths
+        # See --bind in systemd-nspawn(1) for bindmount spec details
+        # Note that this check does not consider all possible formats
+        source_dir = x.split(':')[0]
+        if not os.path.exists(source_dir):
+          logger.warn('Invalid bindmount spec %s: source dir does not exist', x)
+          continue
         cmd += ['-d', x]
 
     cmd.extend(makechrootpkg_args)


### PR DESCRIPTION
Currently lilac tries to bind ~/.cargo to /build/.cargo when building packages in a clean chroot. This patch allows running lilac without creating a dummny ~/.cargo folder.