### PR TITLE
set emails in lilac.py

### DIFF
--- a/lilac
+++ b/lilac
@@ -134,7 +134,14 @@ def send_error_report(name, *, msg=None, exc=None, subject=None):
   if msg is None and exc is None:
     raise TypeError('send_error_report received inefficient args')
 
-  who, tb_find = REPO.find_maintainer_or_admin(package=name)
+  if hasattr(mod, 'emails'):
+    emails = mod.emails
+    tb_find = True
+  else:
+    emails, tb_find = REPO.find_maintainer_or_admin(package=name)
+
+  if not type(emails) is list:
+    emails = [emails]
 
   msgs = []
   if msg is not None:
@@ -165,8 +172,9 @@ def send_error_report(name, *, msg=None, exc=None, subject=None):
     msgs.append('编译命令输出如下：\n\n' + lilaclib.build_output)
 
   msg = '\n'.join(msgs)
-  logger.debug('mail to %s:\nsubject: %s\nbody: %s', who, subject, msg[:200])
-  REPO.sendmail(who, subject, msg)
+  for email in emails:
+    logger.debug('mail to %s:\nsubject: %s\nbody: %s', email, subject, msg[:200])
+    REPO.sendmail(email, subject, msg)
 
 def sign_and_copy():
   pkgs = [x for x in os.listdir() if x.endswith('.pkg.tar.xz')]


### PR DESCRIPTION
目标：
* 在`lilac.py`中添加
```
emails = 'a@b.com'
```
或
```
emails = ['a@b.com']
```
来强制指定收件地址

* 在`lilac.py`中添加
```
emails = ['a@b.com', 'c@d.com']
```
来实现多人的通知(比如征求同意后发送给AUR的maintainer)

* 在`lilac.py`中添加
```
emails = []
```
来实现禁用通知

> PS. 如果lilac.py有错误那还是发给`REPO.find_maintainer_or_admin`...