### PR TITLE
Add a template for aur_dependency change

### DIFF
--- a/templates/README.rst
+++ b/templates/README.rst
@@ -20,6 +20,12 @@ lilac.py-aur_complex
 * See also:
  + `repo/chrome-remote-desktop <https://github.com/archlinuxcn/repo/blob/master/chrome-remote-desktop/lilac.py>`_
 
+lilac.py-aur_dependency
+-----------------------
+稍复杂的 ``lilac.py`` ，用于当AUR包缺少所需依赖时。
+
+可视作 *lilac.py-aur_complex* 的一个特例（修改依赖）。
+
 lilac.py-pypi
 -------------
 从 PyPI 直接构建软件包时使用，除了依赖，几乎不需要进行修改。

--- a/templates/lilac.py-aur_dependency
+++ b/templates/lilac.py-aur_dependency
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# This is a complex version of lilac.py for building
+# a package from AUR with missing depends.
+#
+# This file is based on the lilac.py-aur_complex template.
+#
+# The use case is usually when the upstream forgot to add
+# some dependencies, but wasn't aware of this (e.g. when
+# the dependency is widely installed). Writing a hotfix
+# in lilac.py can make things easier, and does not affect
+# further builds even after upstream fixes this.
+# p.s. Please also report to upstream.
+#
+# `add_depends()` and `add_makedepends()` are provided in
+# `lilac2/pkgbuild.py`, based upon `edit_file`
+#
+
+from lilaclib import *
+
+build_prefix = 'extra-x86_64'
+# depends = []
+
+def pre_build():
+  # obtain base PKGBUILD, e.g.
+  aur_pre_build()
+
+  # add the missing makedepends, e.g.
+  add_makedepends(['git', 'new-makedepend2'])
+
+  # add the missing depends (less usual), e.g.
+  # add_depends(['fancy-depend1', 'fancy-depend2])
+
+def post_build():
+  # do something after the package has successfully been built
+  aur_post_build()
+
+# do some cleanup here after building the package, regardless of result
+# def post_build_always(success):
+#   pass
+
+if __name__ == '__main__':
+  single_main()


### PR DESCRIPTION
Simple template to illustrate the usage of `add_makedepends()` (and `add_depends()`) of `lilac2/pkgbuild.py`.