### PR TITLE
Fix using strings in update_on of lilac.yaml

### DIFF
--- a/lilac2/lilacyaml.py
+++ b/lilac2/lilacyaml.py
@@ -17,7 +17,7 @@ def load_lilac_yaml(dir: pathlib.Path) -> Dict[str, Any]:
   if update_on:
     for i, entry in enumerate(update_on):
       if isinstance(entry, str):
-        update_on[i] = {entry: None}
+        update_on[i] = {entry: ''}
 
   depends = conf.get('depends')
   if depends:


### PR DESCRIPTION
Previously, when lilac.yaml contains the following configuration
```
update_on:
  - vcs
```
The generated nvchecker.ini contains the following section
```
[foobar]
vcs
```
And results in an error
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/nvchecker/core.py", line 152, in worker
    ret = await get_version(name, conf, keyman=self.keymanager)
  File "/usr/lib/python3.7/site-packages/nvchecker/get_version.py", line 62, in get_version
    version = await func(name, conf, **kwargs)
  File "/usr/lib/python3.7/site-packages/nvchecker/source/vcs.py", line 40, in get_version
    stderr=asyncio.subprocess.PIPE,
  File "/usr/lib/python3.7/asyncio/subprocess.py", line 217, in create_subprocess_exec
    stderr=stderr, **kwds)
  File "/usr/lib/python3.7/asyncio/base_events.py", line 1505, in subprocess_exec
    f"program arguments must be a bytes or text string, "
TypeError: program arguments must be a bytes or text string, not NoneType
```
The correct nvchecker configuration should be
```
[foobar]
vcs=
```
So I use an empty string instead