### PR TITLE
Update usage.rst

### DIFF
--- a/usage.rst
+++ b/usage.rst
@@ -39,6 +39,7 @@ lilac 是由百合仙子（a.k.a. `依云 <https://github.com/lilydjwg>`_\ ）�
 为了后续编写及调试 ``lilac.py`` 的方便，应当设置 ``PYTHONPATH`` 环境变量，使 python 能够使用 ``lilaclib`` 。如果使用了上述方法构建了 lilac 调试环境，使用以下代码设置环境变量： ::
 
   export PYTHONPATH=$PYTHONPATH:$HOME/lilac:$HOME/lilac/vendor
+  export PATH=$PATH:$HOME/lilac
 
 使用 lilac
 ==========


### PR DESCRIPTION
`recv_gpg_keys` won't be found if `PATH` isn't set correctly when running single `lilac.py`, which leads to `FileNotFoundError`.