### PR TITLE
Allow to use 'repo_depends' instead of 'depends' in lilac conf

### DIFF
--- a/docs/lilac-py-fields.md
+++ b/docs/lilac-py-fields.md
@@ -15,4 +15,4 @@
 ## 提供的信息
 * `_G.oldver`: 旧版本号。可能为 `None`。
 * `_G.newver`: 新版本号。可能为 `None`。
-* `lilac.yaml` 中的信息（如 `depends`、`maintainers`，已进行基本的解析）
+* `lilac.yaml` 中的信息（如 `repo_depends`、`maintainers`，已进行基本的解析）

--- a/docs/lilac-yaml-schema.yaml
+++ b/docs/lilac-yaml-schema.yaml
@@ -25,8 +25,8 @@ properties:
   time_limit_hours:
     description: Time limit in hours. The build will be aborted if it doesn't finish in time. Default is one hour.
     type: number
-  depends:
-    description: Packages in the repo to be installed before build.
+  repo_depends:
+    description: Packages in the repo to be built and installed before building the current package.
     type: array
     items:
       anyOf:

--- a/lilac2/lilacyaml.py
+++ b/lilac2/lilacyaml.py
@@ -30,7 +30,10 @@ def load_lilac_yaml(dir: pathlib.Path) -> Dict[str, Any]:
       elif 'alias' in entry.keys():
         update_on[i] = ALIASES[entry['alias']]
 
-  depends = conf.get('depends')
+  if 'repo_depends' in conf:
+    depends = conf.get('repo_depends')
+  else:
+    depends = conf.get('depends')
   if depends:
     for i, entry in enumerate(depends):
       if isinstance(entry, dict):

--- a/lilac2/packages.py
+++ b/lilac2/packages.py
@@ -18,7 +18,10 @@ def get_dependency_map(
   rmap: Dict[str, Set[str]] = defaultdict(set)
 
   for name, mod in mods.items():
+    repo_depends = getattr(mod, 'repo_depends', ())
     depends = getattr(mod, 'depends', ())
+    depends = set(depends)
+    depends.union(repo_depends)
 
     ds = [depman.get(d) for d in depends]
     if ds:


### PR DESCRIPTION
同時兼容`depends`和`repo_depends`的使用