### PR TITLE
Do not sign and copy built packages if destdir is empty

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -10,6 +10,8 @@ TERM = xterm
 name = archlinuxcn
 email = repo@example.com
 repodir = /path/to/gitrepo
+# The path where built packages and signatures are copied to
+# Leave it blank (e.g. destdir = ) if there's no need to copy built packages
 destdir = /path/to/pkgdir
 
 [lilac]

--- a/lilac
+++ b/lilac
@@ -163,6 +163,8 @@ def build_package(package: str, mod: LilacMod) -> bool:
   return built_successfully
 
 def sign_and_copy() -> None:
+  if not DESTDIR:
+    return
   pkgs = [x for x in os.listdir() if x.endswith('.pkg.tar.xz')]
   for pkg in pkgs:
     run_cmd(['gpg', '--pinentry-mode', 'loopback', '--passphrase', '',


### PR DESCRIPTION
In some cases people run lilac for testing instead of for distribution,
and thus there's no need to sign and copy built packages.