### PR TITLE
Allow non-first valueless key in update_on

### DIFF
--- a/lilac2/nvchecker.py
+++ b/lilac2/nvchecker.py
@@ -39,6 +39,11 @@ def _gen_config_from_mods(
         newconfig[f'{name}'] = conf
       else:
         newconfig[f'{name}:{i}'] = conf
+        # Avoid valueless keys under numbered name
+        # as nvchecker can't handle that
+        for key, value in conf.items():
+          if not value:
+            conf[key] = name
 
   return newconfig, unknown
 


### PR DESCRIPTION
Enabling such a lilac configuration:
```
update_on:
  - github: foo/bar
  - aur
```