### PR TITLE
WIP: Use `managed` to determine if a package is managed

### DIFF
--- a/docs/lilac-yaml-schema.yaml
+++ b/docs/lilac-yaml-schema.yaml
@@ -71,5 +71,9 @@ properties:
             - github
             - email
     minItems: 1
+  managed:
+    description: Whether the package should be built by lilac or not
+    type: boolean
+    default: true
 required:
   - maintainers

--- a/lilac
+++ b/lilac
@@ -7,7 +7,6 @@ import logging
 import configparser
 import time
 from collections import defaultdict
-import pathlib
 from typing import Set, Dict, List, Tuple, Any
 import textwrap
 
@@ -104,7 +103,7 @@ def build_package(package: str, mod: LilacMod) -> bool:
     try:
       with execution_timeout(time_limit_hours * 3600):
         lilac_build(
-          mod,
+          REPO, mod,
           oldver = n[0], newver = n[1],
           depends = DEPENDS.get(package, ()),
           bindmounts = BIND_MOUNTS,
@@ -181,7 +180,7 @@ def git_last_commit() -> str:
   cmd = ['git', 'log', '-1', '--format=%H']
   return run_cmd(cmd).strip()
 
-def start_build(mods: LilacMods, failed: Set[str], built: Set[str]) -> None:
+def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
   # built is used to collect built package names
   global DEPENDS
 
@@ -194,7 +193,7 @@ def start_build(mods: LilacMods, failed: Set[str], built: Set[str]) -> None:
   for name, ds in building_depmap.items():
     for d in ds:
       if not d.resolve():
-        if not d.managed():
+        if not repo.managed(d):
           logger.warning('%s depends on %s, but it\'s not managed.',
                          name, d)
           nonexistent[name].append(d)
@@ -213,7 +212,7 @@ def start_build(mods: LilacMods, failed: Set[str], built: Set[str]) -> None:
 
   for name, deps in nonexistent.items():
     REPO.send_error_report(
-      mods[name], subject='软件包 %s 的 lilac.py 指定了不存在的依赖',
+      repo.mods[name], subject='软件包 %s 的 lilac.py 指定了不存在的依赖',
       msg = f'''软件包 {name} 的 lilac.py 指定了 depends，然而其直接或者间接的依赖项 {deps!r} 并不在本仓库中。
 ''')
 
@@ -286,9 +285,9 @@ def start_build(mods: LilacMods, failed: Set[str], built: Set[str]) -> None:
     logger.info('keyboard interrupted, bye~')
 
 def load_all_lilac_and_report(
-  repodir: pathlib.Path,
+  repo,
 ) -> Tuple[LilacMods, Set[str]]:
-  mods, errors = lilacpy.load_all(repodir)
+  errors = lilacpy.load_all(repo)
   failed = set(errors)
   for name, exc_info in errors.items():
     tb_lines = traceback.format_exception(*exc_info)
@@ -297,12 +296,12 @@ def load_all_lilac_and_report(
     exc = exc_info[1]
     if not isinstance(exc, Exception):
       raise
-    REPO.send_error_report(name, exc=(exc, tb),
+    repo.send_error_report(name, exc=(exc, tb),
                            subject='为软件包 %s 载入 lilac.py 时失败')
     build_logger_old.error('%s failed', name)
     build_logger.exception('lilac.py error', pkgbase = name)
 
-  return mods, failed
+  return failed
 
 def main_may_raise(D: Dict[str, Any], pkgs_to_build: List[str]) -> None:
   global DEPMAP
@@ -314,20 +313,20 @@ def main_may_raise(D: Dict[str, Any], pkgs_to_build: List[str]) -> None:
 
   git_reset_hard()
   git_pull()
-  mods, failed = load_all_lilac_and_report(REPO.repodir)
+  failed = load_all_lilac_and_report(REPO)
 
   depman = DependencyManager(REPO.repodir)
-  DEPMAP = get_dependency_map(depman, mods)
+  DEPMAP = get_dependency_map(depman, REPO.mods)
 
   if pkgs_to_build:
-    all_mods = mods
-    mods = {}
+    all_mods = REPO.mods
+    REPO.mods = {}
     for pkg_to_build in pkgs_to_build:
       for dep in DEPMAP[pkg_to_build]:
-        mods[dep.pkgname] = all_mods[dep.pkgname]
-      mods[pkg_to_build] = all_mods[pkg_to_build]
+        REPO.mods[dep.pkgname] = all_mods[dep.pkgname]
+      REPO.mods[pkg_to_build] = all_mods[pkg_to_build]
 
-  _nvdata, unknown, rebuild = packages_need_update(REPO, mods)
+  _nvdata, unknown, rebuild = packages_need_update(REPO)
   nvdata.update(_nvdata)
 
   if pkgs_to_build:
@@ -336,7 +335,7 @@ def main_may_raise(D: Dict[str, Any], pkgs_to_build: List[str]) -> None:
     need_rebuild_pkgrel: Set[str] = set()
     rebuild = rebuild | set(pkgs_to_build)
   else:
-    U = set(mods)
+    U = set(REPO.mods)
     last_commit = D.get('last_commit', EMPTY_COMMIT)
     changed = get_changed_packages(last_commit, 'HEAD') & U
 
@@ -373,7 +372,7 @@ def main_may_raise(D: Dict[str, Any], pkgs_to_build: List[str]) -> None:
   update_succeeded: Set[str] = set()
 
   try:
-    start_build(mods, failed, update_succeeded)
+    start_build(REPO, failed, update_succeeded)
     D['last_commit'] = git_last_commit()
   finally:
     # handle what has been processed even on exception
@@ -386,14 +385,14 @@ def main_may_raise(D: Dict[str, Any], pkgs_to_build: List[str]) -> None:
 
     if config.getboolean('lilac', 'rebuild_failed_pkgs'):
       if update_succeeded:
-        nvtake(update_succeeded, mods)
+        nvtake(update_succeeded, REPO.mods)
     else:
       if need_update or rebuild:
         # only nvtake packages we have tried to build (excluding unbuilt
         # packages due to internal errors)
         built = update_succeeded | failed
         update_nv = built & (need_update | rebuild)
-        nvtake(update_nv, mods)
+        nvtake(update_nv, REPO.mods)
 
     git_reset_hard()
     if config.getboolean('lilac', 'git_push'):

--- a/lilac
+++ b/lilac
@@ -210,7 +210,7 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
           x.pkgdir.name for x in DEPMAP[pkgbase]}
 
   for name, deps in nonexistent.items():
-    REPO.send_error_report(
+    repo.send_error_report(
       repo.mods[name], subject='软件包 %s 的 lilac.py 指定了不存在的依赖',
       msg = f'''软件包 {name} 的 lilac.py 指定了 depends，然而其直接或者间接的依赖项 {deps!r} 并不在本仓库中。
 ''')
@@ -237,7 +237,7 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
         # marked as failed, skip
         continue
 
-      path = REPO.repodir / pkg
+      path = repo.repodir / pkg
       with at_dir(path):
         try:
           if build_package(pkg, repo.mods[pkg]):
@@ -252,7 +252,7 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
           if e.packages:
             reason += f'软件包将取代官方包：{e.packages}\n'
 
-          REPO.send_error_report(
+          repo.send_error_report(
             repo.mods[pkg],
             subject='%s 与官方软件库冲突',
             msg = reason,
@@ -266,7 +266,7 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
           if faileddeps:
             reason += '唔，这些包没能成功打包呢：%r' % faileddeps
 
-          REPO.send_error_report(repo.mods[pkg], subject='%s 出现依赖问题',
+          repo.send_error_report(repo.mods[pkg], subject='%s 出现依赖问题',
                                  msg = '''\
 在成功地编译打包 {built} 之后，{pkg} 依旧依赖 {deps}。
 
@@ -275,7 +275,7 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
   ))
           failed.add(pkg)
         except pkgbuild.DowngradingError as e:
-          REPO.send_error_report(repo.mods[pkg], subject='%s 新打的包比仓库里的包旧', msg=textwrap.dedent(f'''
+          repo.send_error_report(repo.mods[pkg], subject='%s 新打的包比仓库里的包旧', msg=textwrap.dedent(f'''
           包 {e.pkgname} 打的版本为 {e.built_version}，但在仓库里已有较新版本 {e.repo_version}。
           '''))
           failed.add(pkg)

--- a/lilac
+++ b/lilac
@@ -103,7 +103,7 @@ def build_package(package: str, mod: LilacMod) -> bool:
     try:
       with execution_timeout(time_limit_hours * 3600):
         lilac_build(
-          REPO, mod,
+          mod, REPO,
           oldver = n[0], newver = n[1],
           depends = DEPENDS.get(package, ()),
           bindmounts = BIND_MOUNTS,
@@ -241,7 +241,7 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
       path = REPO.repodir / pkg
       with at_dir(path):
         try:
-          if build_package(pkg, mods[pkg]):
+          if build_package(pkg, repo.mods[pkg]):
             built.add(pkg)
           else:
             failed.add(pkg)
@@ -254,7 +254,7 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
             reason += f'软件包将取代官方包：{e.packages}\n'
 
           REPO.send_error_report(
-            mods[pkg],
+            repo.mods[pkg],
             subject='%s 与官方软件库冲突',
             msg = reason,
           )
@@ -267,7 +267,7 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
           if faileddeps:
             reason += '唔，这些包没能成功打包呢：%r' % faileddeps
 
-          REPO.send_error_report(mods[pkg], subject='%s 出现依赖问题',
+          REPO.send_error_report(repo.mods[pkg], subject='%s 出现依赖问题',
                                  msg = '''\
 在成功地编译打包 {built} 之后，{pkg} 依旧依赖 {deps}。
 
@@ -276,7 +276,7 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
   ))
           failed.add(pkg)
         except pkgbuild.DowngradingError as e:
-          REPO.send_error_report(mods[pkg], subject='%s 新打的包比仓库里的包旧', msg=textwrap.dedent(f'''
+          REPO.send_error_report(repo.mods[pkg], subject='%s 新打的包比仓库里的包旧', msg=textwrap.dedent(f'''
           包 {e.pkgname} 打的版本为 {e.built_version}，但在仓库里已有较新版本 {e.repo_version}。
           '''))
           failed.add(pkg)

--- a/lilac
+++ b/lilac
@@ -7,7 +7,7 @@ import logging
 import configparser
 import time
 from collections import defaultdict
-from typing import Set, Dict, List, Tuple, Any
+from typing import Set, Dict, List, Any
 import textwrap
 
 from toposort import toposort_flatten
@@ -21,7 +21,6 @@ from myutils import at_dir, execution_timeout, lock_file
 from serializer import PickledData
 from nicelogger import enable_pretty_logging
 
-from lilac2 import lilacpy
 from lilac2.packages import (
   DependencyManager, get_dependency_map, get_changed_packages,
   Dependency,
@@ -34,7 +33,7 @@ from lilac2.tools import kill_child_processes
 from lilac2.repo import Repo
 from lilac2.const import mydir, _G
 from lilac2.nvchecker import packages_need_update, nvtake, NvResult
-from lilac2.typing import LilacMod, LilacMods
+from lilac2.typing import LilacMod
 from lilac2 import pkgbuild
 from lilac2.building import lilac_build, MissingDependencies, SkipBuild
 import lilac2.building as B
@@ -284,25 +283,6 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
   except KeyboardInterrupt:
     logger.info('keyboard interrupted, bye~')
 
-def load_all_lilac_and_report(
-  repo,
-) -> Tuple[LilacMods, Set[str]]:
-  errors = lilacpy.load_all(repo)
-  failed = set(errors)
-  for name, exc_info in errors.items():
-    tb_lines = traceback.format_exception(*exc_info)
-    tb = ''.join(tb_lines)
-    logger.error('error while loading lilac.py for %s', name, exc_info=exc_info)
-    exc = exc_info[1]
-    if not isinstance(exc, Exception):
-      raise
-    repo.send_error_report(name, exc=(exc, tb),
-                           subject='为软件包 %s 载入 lilac.py 时失败')
-    build_logger_old.error('%s failed', name)
-    build_logger.exception('lilac.py error', pkgbase = name)
-
-  return failed
-
 def main_may_raise(D: Dict[str, Any], pkgs_to_build: List[str]) -> None:
   global DEPMAP
 
@@ -313,7 +293,7 @@ def main_may_raise(D: Dict[str, Any], pkgs_to_build: List[str]) -> None:
 
   git_reset_hard()
   git_pull()
-  failed = load_all_lilac_and_report(REPO)
+  failed = REPO.load_all_lilac_and_report()
 
   depman = DependencyManager(REPO.repodir)
   DEPMAP = get_dependency_map(depman, REPO.mods)

--- a/lilac
+++ b/lilac
@@ -193,7 +193,7 @@ def start_build(repo: Repo, failed: Set[str], built: Set[str]) -> None:
   for name, ds in building_depmap.items():
     for d in ds:
       if not d.resolve():
-        if not repo.managed(d):
+        if not repo.manages(d):
           logger.warning('%s depends on %s, but it\'s not managed.',
                          name, d)
           nonexistent[name].append(d)

--- a/lilac2/api.py
+++ b/lilac2/api.py
@@ -354,7 +354,7 @@ def single_main(build_prefix: str = 'makepkg') -> None:
   enable_pretty_logging('DEBUG')
   with lilacpy.load_lilac(Path('.')) as mod:
     lilac_build(
-      mod,
+      mod, None,
       build_prefix = build_prefix,
       accept_noupdate = True,
     )

--- a/lilac2/building.py
+++ b/lilac2/building.py
@@ -25,7 +25,7 @@ class SkipBuild(Exception):
     self.msg = msg
 
 def lilac_build(
-  mod: LilacMod, build_prefix: Optional[str] = None,
+  mod: LilacMod, repo, build_prefix: Optional[str] = None,
   oldver: Optional[str] = None, newver: Optional[str] = None,
   accept_noupdate: bool = False,
   depends: Iterable[Dependency] = (),
@@ -64,7 +64,7 @@ def lilac_build(
     for x in depends:
       p = x.resolve()
       if p is None:
-        if not x.managed():
+        if not repo.managed(x):
           # ignore depends that are not in repo
           continue
         need_build_first.add(x.pkgname)

--- a/lilac2/building.py
+++ b/lilac2/building.py
@@ -64,7 +64,7 @@ def lilac_build(
     for x in depends:
       p = x.resolve()
       if p is None:
-        if not repo.managed(x):
+        if not repo.manages(x):
           # ignore depends that are not in repo
           continue
         need_build_first.add(x.pkgname)

--- a/lilac2/nvchecker.py
+++ b/lilac2/nvchecker.py
@@ -24,11 +24,11 @@ class NvResult(NamedTuple):
   newver: Optional[str]
 
 def _gen_config_from_mods(
-  repo: Repo,
+  mods: LilacMods,
 ) -> Tuple[Dict[str, Any], Set[str]]:
   unknown = set()
   newconfig = {}
-  for name, mod in repo.mods.items():
+  for name, mod in mods.items():
     confs = getattr(mod, 'update_on', None)
     if not confs:
       unknown.add(name)
@@ -50,7 +50,7 @@ def _gen_config_from_mods(
 def packages_need_update(
   repo: Repo,
 ) -> Tuple[Dict[str, NvResult], Set[str], Set[str]]:
-  newconfig, unknown = _gen_config_from_mods(repo)
+  newconfig, unknown = _gen_config_from_mods(repo.mods)
 
   if not OLDVER_FILE.exists():
     open(OLDVER_FILE, 'a').close()

--- a/lilac2/nvchecker.py
+++ b/lilac2/nvchecker.py
@@ -24,11 +24,11 @@ class NvResult(NamedTuple):
   newver: Optional[str]
 
 def _gen_config_from_mods(
-  repo: Repo, mods: LilacMods,
+  repo: Repo,
 ) -> Tuple[Dict[str, Any], Set[str]]:
   unknown = set()
   newconfig = {}
-  for name, mod in mods.items():
+  for name, mod in repo.mods.items():
     confs = getattr(mod, 'update_on', None)
     if not confs:
       unknown.add(name)
@@ -48,9 +48,9 @@ def _gen_config_from_mods(
   return newconfig, unknown
 
 def packages_need_update(
-  repo: Repo, mods: LilacMods,
+  repo: Repo,
 ) -> Tuple[Dict[str, NvResult], Set[str], Set[str]]:
-  newconfig, unknown = _gen_config_from_mods(repo, mods)
+  newconfig, unknown = _gen_config_from_mods(repo)
 
   if not OLDVER_FILE.exists():
     open(OLDVER_FILE, 'a').close()
@@ -116,7 +116,7 @@ def packages_need_update(
       missing.append(pkg)
       continue
 
-    maintainers = repo.find_maintainers(mods[pkg])
+    maintainers = repo.find_maintainers(repo.mods[pkg])
     for maintainer in maintainers:
       error_owners[maintainer].extend(pkgerrs)
 
@@ -140,7 +140,7 @@ def packages_need_update(
           '\n'.join( missing) + '\n'
     repo.send_repo_mail(subject, msg)
 
-  for name in mods:
+  for name in repo.mods:
     if name not in nvdata:
       # we know nothing about these versions
       # maybe nvchecker has failed

--- a/lilac2/packages.py
+++ b/lilac2/packages.py
@@ -47,9 +47,6 @@ class Dependency(_DependencyTuple):
     except FileNotFoundError:
       return None
 
-  def managed(self) -> bool:
-    return (self.pkgdir / 'lilac.py').exists()
-
   def _find_local_package(self) -> Path:
     files = [x for x in self.pkgdir.iterdir()
              if x.name.endswith('.pkg.tar.xz')]

--- a/lilac2/repo.py
+++ b/lilac2/repo.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Optional, Tuple, List, Union, Dict
 import logging
 from functools import lru_cache
-import os.path
 
 from github import GitHub
 
@@ -187,5 +186,5 @@ class Repo:
   def send_repo_mail(self, subject: str, msg: str) -> None:
     self.ms.sendmail(self.repomail, subject, msg)
 
-  def managed(self, dep) -> bool:
-    return os.path.basename(dep.pkgdir) in self.mods
+  def manages(self, dep) -> bool:
+    return dep.pkgdir.name in self.mods

--- a/lilac2/repo.py
+++ b/lilac2/repo.py
@@ -1,19 +1,23 @@
 import subprocess
 from pathlib import Path
-from typing import Optional, Tuple, List, Union, Dict
+from typing import Optional, Tuple, List, Union, Dict, Set
 import logging
 from functools import lru_cache
+import traceback
 
 from github import GitHub
+import structlog
 
 from .mail import MailService
 from .typing import LilacMod, Maintainer
 from .tools import ansi_escape_re
-from . import api
+from . import api, lilacpy
 from .building import build_output
 from .typing import LilacMods
 
 logger = logging.getLogger(__name__)
+build_logger_old = logging.getLogger('build')
+build_logger = structlog.get_logger(logger_name='build')
 
 class Repo:
   def __init__(self, config):
@@ -33,7 +37,7 @@ class Repo:
     else:
       self.gh = None
 
-    self.mods: LilacMods = {}  # to be filled by lilacpy.load_all()
+    self.mods: LilacMods = {}  # to be filled by self.load_all_lilac_and_report()
 
   @lru_cache()
   def maintainer_from_github(self, username: str) -> Optional[Maintainer]:
@@ -188,3 +192,20 @@ class Repo:
 
   def manages(self, dep) -> bool:
     return dep.pkgdir.name in self.mods
+
+  def load_all_lilac_and_report(self) -> Set[str]:
+    self.mods, errors = lilacpy.load_all(self.repodir)
+    failed = set(errors)
+    for name, exc_info in errors.items():
+      tb_lines = traceback.format_exception(*exc_info)
+      tb = ''.join(tb_lines)
+      logger.error('error while loading lilac.py for %s', name, exc_info=exc_info)
+      exc = exc_info[1]
+      if not isinstance(exc, Exception):
+        raise
+      self.send_error_report(name, exc=(exc, tb),
+                             subject='为软件包 %s 载入 lilac.py 时失败')
+      build_logger_old.error('%s failed', name)
+      build_logger.exception('lilac.py error', pkgbase = name)
+
+    return failed

--- a/lilac2/repo.py
+++ b/lilac2/repo.py
@@ -11,6 +11,7 @@ from .typing import LilacMod, Maintainer
 from .tools import ansi_escape_re
 from . import api
 from .building import build_output
+from .typing import LilacMods
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,8 @@ class Repo:
       self.gh = GitHub(config.get('lilac', 'github_token', fallback=None))
     else:
       self.gh = None
+
+    self.mods: LilacMods = {}  # to be filled by lilacpy.load_all()
 
   @lru_cache()
   def maintainer_from_github(self, username: str) -> Optional[Maintainer]:
@@ -183,3 +186,5 @@ class Repo:
   def send_repo_mail(self, subject: str, msg: str) -> None:
     self.ms.sendmail(self.repomail, subject, msg)
 
+  def managed(self, dep) -> bool:
+    return dep.pkgdir in self.mods

--- a/lilac2/repo.py
+++ b/lilac2/repo.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional, Tuple, List, Union, Dict
 import logging
 from functools import lru_cache
+import os.path
 
 from github import GitHub
 
@@ -187,4 +188,4 @@ class Repo:
     self.ms.sendmail(self.repomail, subject, msg)
 
   def managed(self, dep) -> bool:
-    return dep.pkgdir in self.mods
+    return os.path.basename(dep.pkgdir) in self.mods


### PR DESCRIPTION
docs/lilac-yaml-schema.yaml is also updated in https://github.com/archlinuxcn/repo/pull/1163.

Currently lilac.yaml are loaded twice for each package - one in `load_lilac_yaml()` of lilac2/lilacyaml.py and another in `Dependency.managed()` of lilac2/packages.py. I think it should be refactored so that each lilac.yaml is loaded only once.