### PR TITLE
add some unittests of api.py

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,0 +1,29 @@
+import pathlib
+import sys
+
+import pytest
+
+this_dir = pathlib.Path(__file__).resolve()
+sys.path.insert(0, str(this_dir.parents[1]))
+
+from lilac2.api import (
+    _unquote_item,
+    _add_into_array,
+)
+
+@pytest.mark.parametrize('shell_str, python_str', [
+  ('"abc"', 'abc'),
+  ("'abc'", 'abc'),
+])
+def test_unquote_item(shell_str, python_str):
+  assert _unquote_item(shell_str) == python_str
+
+@pytest.mark.parametrize('line, extra_elements, line_expected', [
+  ("some_array = ()", ["ab", "bc"], "some_array = ('ab' 'bc')"),
+  ("some_array = ('ab', 'bc')", ["cd"], "some_array = ('ab' 'bc' 'cd')"),
+  ('''some_array = ("ab" "bc")''', ["cd"], "some_array = ('ab' 'bc' 'cd')"),
+  ('''some_array = ("ab" 'bc')''', ["cd"], "some_array = ('ab' 'bc' 'cd')"),
+])
+def test_add_into_array(line, extra_elements, line_expected):
+  assert _add_into_array(line, extra_elements) == line_expected
+


### PR DESCRIPTION
增加單元測試來輔助開發與debug。

其實是發現`api.add_into_array()`有一點小問題（特定條件下會出問題），爲了輔助修正，順便增加單元測試。

<del>話說 `test/test_lilaclib.py`是怎麼用的？需要加到`run_test.sh`裏麼？</del>