### PR TITLE
Fix some problems of add_into_array()

### DIFF
--- a/lilac2/api.py
+++ b/lilac2/api.py
@@ -44,12 +44,15 @@ def _unquote_item(s: str) -> Optional[str]:
 def _add_into_array(line: str, values: Iterable[str]) -> str:
   l = line.find('(')
   r = line.rfind(')')
-  arr_str = line[l+1:r].strip()
-  arr = {_unquote_item(x) for x in arr_str.split(' ')}.union(values)
+  if r != -1:
+    line_l, line_m, line_r = line[:l+1], line[l+1:r], line[r:]
+  else:
+    line_l, line_m, line_r = line[:l+1], line[l+1:], ''
+  arr = {_unquote_item(x) for x in line_m.split(' ')}.union(values)
   arr_nonone = [i for i in arr if i is not None]
   arr_nonone.sort()
-  arr_str = "('{}')".format("' '".join(arr_nonone))
-  line = line[:l] + arr_str
+  arr_elems_str = "'{}'".format("' '".join(arr_nonone))
+  line = line_l + arr_elems_str + line_r
   return line
 
 def add_into_array(which: str, extra_deps: Iterable[str]) -> None:

--- a/lilac2/api.py
+++ b/lilac2/api.py
@@ -61,8 +61,9 @@ def add_into_array(which: str, extra_deps: Iterable[str]) -> None:
   '''
   field_appeared = False
 
+  pattern = re.compile(r'\s*' + re.escape(which) + r'=')
   for line in edit_file('PKGBUILD'):
-    if line.strip().startswith(which):
+    if pattern.match(line):
       line = _add_into_array(line, extra_deps)
       field_appeared = True
     print(line)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,10 +13,11 @@ def test_unquote_item(shell_str, python_str):
   assert _unquote_item(shell_str) == python_str
 
 @pytest.mark.parametrize('line, extra_elements, line_expected', [
-  ("some_array = ()", ["ab", "bc"], "some_array = ('ab' 'bc')"),
-  ("some_array = ('ab', 'bc')", ["cd"], "some_array = ('ab' 'bc' 'cd')"),
-  ('''some_array = ("ab" "bc")''', ["cd"], "some_array = ('ab' 'bc' 'cd')"),
-  ('''some_array = ("ab" 'bc')''', ["cd"], "some_array = ('ab' 'bc' 'cd')"),
+  ("some_array=()", ["ab", "bc"], "some_array=('ab' 'bc')"),
+  ("some_array=('ab', 'bc')", ["cd"], "some_array=('ab' 'bc' 'cd')"),
+  ('''some_array=("ab" "bc")''', ["cd"], "some_array=('ab' 'bc' 'cd')"),
+  ('''some_array=("ab" 'bc')''', ["cd"], "some_array=('ab' 'bc' 'cd')"),
+  ('''some_array=("ab"''', ["cd"], "some_array=('ab' 'cd'"),
 ])
 def test_add_into_array(line, extra_elements, line_expected):
   assert _add_into_array(line, extra_elements) == line_expected


### PR DESCRIPTION
0eadbe1 should now correctly check variable start. If the variable is not an array, that's a (bigger) problem of the PKGBUILD.

88ff86f is actually another implementation of #121, with fewer lines and no conflict.

Maybe I should split this PR into two?