### PR TITLE
update key in DependencyManager._CACHE

### DIFF
--- a/lilac2/packages.py
+++ b/lilac2/packages.py
@@ -79,10 +79,11 @@ class DependencyManager:
     else:
       pkgbase = pkgname = what
 
-    if pkgname not in self._CACHE:
-      self._CACHE[pkgname] = Dependency(
+    key = '/'.join((pkgbase, pkgname))
+    if key not in self._CACHE:
+      self._CACHE[key] = Dependency(
         self.repodir / pkgbase, pkgname)
-    return self._CACHE[pkgname]
+    return self._CACHE[key]
 
 def get_changed_packages(from_: str, to: str) -> Set[str]:
   cmd = ["git", "diff", "--name-only", '--relative', from_, to]


### PR DESCRIPTION
如题，原来的在有比如
```
seafile 依赖 libseafile-*-x86_64.pkg.tar.xz
seafile-aarch64 依赖 libseafile-*-aarch64.pkg.tar.xz
seafile-armv6h 依赖 libseafile-*-armv6h.pkg.tar.xz
seafile-armv7h 依赖 libseafile-*-armv7h.pkg.tar.xz
```
的情况下，会把`seafile{,-aarch64,-armv6h,-armv7h}`都依赖到`libseafile-*-armv7h.pkg.tar.xz`上去，导致非 armv7h 的就打包不成功了