### PR TITLE
Fixed key in dependency map

### DIFF
--- a/lilac2/packages.py
+++ b/lilac2/packages.py
@@ -25,8 +25,8 @@ def get_dependency_map(
     ds = [depman.get(d) for d in depends]
     if ds:
       for d in ds:
-        shallow_map[name].add(d.pkgname)
-        rmap[d.pkgname].add(name)
+        shallow_map[name].add(d.pkgdir)
+        rmap[d.pkgdir].add(name)
       map[name].update(ds)
 
   dep_order = toposort_flatten(shallow_map)


### PR DESCRIPTION
这个我还不确定修的对不对。

目前是遇到了这么个问题。
在x86_64及ARM架构下，均有下述依赖关系的3个包
```
seafile 依赖 libsearpc, ccnet-server
ccnet-server 依赖 libsearpc
libsearpc 无依赖
```
然而现在build seafile-armv6h的时候，会解析出(ccnet-server-armv6h, ccnet-server) (libsearpc-armv6h, libsearpc) (libsearpc, libsearpc) 三个依赖，其中最后一个为x86_64的

这么改了以后就只有前两个依赖了。