### PR TITLE
Add an alias for nvchecker's alpm source

### DIFF
--- a/lilac
+++ b/lilac
@@ -41,7 +41,7 @@ from lilac2.cmd import (
 )
 from lilac2.tools import kill_child_processes, redirect_output
 from lilac2.repo import Repo
-from lilac2.const import mydir, _G
+from lilac2.const import mydir, _G, PACMAN_DB_DIR
 from lilac2.nvchecker import packages_need_update, nvtake, NvResults
 from lilac2.typing import LilacMod
 from lilac2 import pkgbuild
@@ -450,9 +450,7 @@ def setup() -> None:
   setup_build_logger()
   os.chdir(REPO.repodir)
 
-  dbpath = mydir / 'pacmandb'
-  dbpath.mkdir(exist_ok=True)
-  pkgbuild.init_data(dbpath)
+  pkgbuild.init_data(PACMAN_DB_DIR)
 
 if __name__ == '__main__':
   try:

--- a/lilac2/aliases.yaml
+++ b/lilac2/aliases.yaml
@@ -48,3 +48,7 @@ mediawiki:
   archpkg: mediawiki
   from_pattern: '^(\d+\.\d+)\..*'
   to_pattern: '\1'
+alpm-lilac:
+  source: alpm
+  dbpath: '{pacman_db_dir}'
+  repo: '{repo_name}'

--- a/lilac2/const.py
+++ b/lilac2/const.py
@@ -6,6 +6,8 @@ import types
 mydir = Path('~/.lilac').expanduser()
 AUR_REPO_DIR = mydir / 'aur'
 AUR_REPO_DIR.mkdir(parents=True, exist_ok=True)
+PACMAN_DB_DIR = mydir / 'pacmandb'
+PACMAN_DB_DIR.mkdir(exist_ok=True)
 
 SPECIAL_FILES = ('package.list', 'lilac.py', 'lilac.yaml', '.gitignore')
 

--- a/lilac2/lilacpy.py
+++ b/lilac2/lilacpy.py
@@ -6,6 +6,7 @@ import importlib.util
 from pathlib import Path
 from typing import Generator, cast, Dict, Tuple
 
+from .const import _G, PACMAN_DB_DIR
 from .typing import LilacMod, LilacMods, ExcInfo
 from .lilacyaml import (
   load_lilac_yaml, ALIASES, iter_pkgdir,
@@ -33,6 +34,12 @@ def load_all(repodir: Path) -> Tuple[LilacMods, Dict[str, ExcInfo]]:
       errors[x.name] = cast(ExcInfo, sys.exc_info())
 
   return mods, errors
+
+def expand_alias_arg(value: str) -> str:
+  return value.format(
+    pacman_db_dir=PACMAN_DB_DIR,
+    repo_name=_G.repo.name,
+  )
 
 @contextlib.contextmanager
 def load_lilac(dir: Path) -> Generator[LilacMod, None, None]:
@@ -81,7 +88,7 @@ def load_lilac(dir: Path) -> Generator[LilacMod, None, None]:
         alias = entry.pop('alias', None)
         if alias is not None:
           for k, v in ALIASES[alias].items():
-            entry.setdefault(k, v)
+            entry.setdefault(k, expand_alias_arg(v))
 
     yield mod
 
@@ -90,4 +97,3 @@ def load_lilac(dir: Path) -> Generator[LilacMod, None, None]:
       del sys.modules['lilac.py']
     except KeyError:
       pass
-


### PR DESCRIPTION
This makes it easier to use the new `alpm` source introduced in lilydjwg/nvchecker#168.