### PR TITLE
[WIP] adding lilac3

### DIFF
--- a/.github/workflows/seeker.yml
+++ b/.github/workflows/seeker.yml
@@ -1,0 +1,60 @@
+name: seeker
+
+on: workflow_dispatch
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux
+
+    steps:
+      - name: Get time
+        id: time
+        run: echo "::set-output name=time::$(date +%F-%T)"
+
+      - name: Set up pacman db cache
+        uses: actions/cache@master
+        with:
+          path: /var/lib/pacman/sync
+          key: pacman-db-x86_64-${{ steps.time.outputs.time }}
+          restore-keys: pacman-db-x86_64-
+
+      - name: Set up pacman package cache
+        uses: actions/cache@master
+        with:
+          path: /var/cache/pacman/pkg
+          key: pacman-package-x86_64-${{ steps.time.outputs.time }}
+          restore-keys: pacman-package-x86_64-
+
+      - name: Install runtime dependencies
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm --needed nvchecker python-django python-mysqlclient python-toml python-tornado python-yaml
+
+      - uses: actions/checkout@master
+        with:
+          path: lilac
+
+      - uses: actions/checkout@master
+        with:
+          repository: petronny/djangorm
+          path: djangorm
+
+      - uses: actions/checkout@master
+        with:
+          repository: ${{ secrets.REPOSITORY }}
+          path: repository
+
+      - name: Collecting lilac.yaml
+        run: python lilac/lilac3/seeker/collect.py repository
+
+      - name: Run nvchecker
+        run: nvchecker --logger both -c nvchecker.toml
+
+      - name: Update database
+        env:
+          RECORDER_DATABASE: ${{ secrets.RECORDER_DATABASE }}
+          PYTHONPATH: .:lilac/lilac3
+        run: python lilac/lilac3/seeker/update.py

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,0 +1,54 @@
+name: Trigger rebuild
+
+on:
+  workflow_dispatch:
+    inputs:
+      pkgbase:
+        description: 'Path to pkgbase'
+        required: true
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux
+
+    steps:
+      - name: Get time
+        id: time
+        run: echo "::set-output name=time::$(date +%F-%T)"
+
+      - name: Set up pacman db cache
+        uses: actions/cache@master
+        with:
+          path: /var/lib/pacman/sync
+          key: pacman-db-x86_64-${{ steps.time.outputs.time }}
+          restore-keys: pacman-db-x86_64-
+
+      - name: Set up pacman package cache
+        uses: actions/cache@master
+        with:
+          path: /var/cache/pacman/pkg
+          key: pacman-package-x86_64-${{ steps.time.outputs.time }}
+          restore-keys: pacman-package-x86_64-
+
+      - name: Install runtime dependencies
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm --needed python-django python-mysqlclient
+
+      - uses: actions/checkout@master
+        with:
+          path: lilac
+
+      - uses: actions/checkout@master
+        with:
+          repository: petronny/djangorm
+          path: djangorm
+
+      - name: Update database
+        env:
+          RECORDER_DATABASE: ${{ secrets.RECORDER_DATABASE }}
+          PYTHONPATH: .:lilac/lilac3
+        run: python lilac/lilac3/seeker/trigger.py ${{ github.event.inputs.pkgbase }}

--- a/lilac3/.gitignore
+++ b/lilac3/.gitignore
@@ -1,0 +1,5 @@
+*.toml
+__pycache__
+*.json
+djangorm
+config.py

--- a/lilac3/common/options.py
+++ b/lilac3/common/options.py
@@ -1,0 +1,39 @@
+class Options(dict):
+
+    def __getitem__(self, key):
+        if not key in self.keys():
+            self.__setitem__(key, Options())
+        return super().__getitem__(key)
+
+    def __getattr__(self, attr):
+        if not attr in self.keys():
+            self[attr] = Options()
+        return self[attr]
+
+    def __setattr__(self, attr, value):
+        self[attr] = value
+
+    def __delattr__(self, attr):
+        del self[attr]
+
+if __name__ == '__main__':
+    import json
+
+    config = Options()
+    config.test = 'test'
+    config['test2'] = 'test2'
+    print(config)
+    config['test'] = 'test2'
+    config.test2 = 'test'
+    print(config)
+    del config.test
+    print(config)
+    del config['test2']
+    print(config)
+    config.test.test = 'test'
+    config['test2'].test2 = 'test2'
+    print(config)
+    config.test['test'] = 'test2'
+    config['test2']['test2'] = 'test'
+    print(config)
+    print(json.dumps(config))

--- a/lilac3/recorder/.gitignore
+++ b/lilac3/recorder/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.sqlite3
+migrations

--- a/lilac3/recorder/__init__.py
+++ b/lilac3/recorder/__init__.py
@@ -1,0 +1,14 @@
+#!/bin/python
+import os
+import json
+from pathlib import Path
+from djangorm import DjangORM
+
+if 'RECORDER_DATABASE' in os.environ:
+    database = json.loads(os.environ['RECORDER_DATABASE'])
+else:
+    database = None
+
+db = DjangORM(module_name=Path(__file__).parent.name, database=database, module_path=Path(__file__).parent.parent)
+db.configure()
+db.migrate()

--- a/lilac3/recorder/config.py
+++ b/lilac3/recorder/config.py
@@ -1,0 +1,17 @@
+#!/bin/python
+
+if __name__ == '__main__':
+    import json
+    from common.options import Options
+
+    config = Options()
+    config.ENGINE = 'django.db.backends.mysql'
+    config.HOST = 'host'
+    config.PORT = 'port'
+    config.NAME = 'database'
+    config.USER = 'username'
+    config.PASSWORD = 'password'
+    config.OPTIONS.charset = 'utf8mb4'
+    config.OPTIONS.init_command = "SET sql_mode='STRICT_TRANS_TABLES'"
+
+    print(json.dumps(config))

--- a/lilac3/recorder/models.py
+++ b/lilac3/recorder/models.py
@@ -1,0 +1,13 @@
+from django.db import models
+
+class Version(models.Model):
+    key = models.CharField(max_length=50, default="")
+    oldver = models.CharField(max_length=50, default="")
+    newver = models.CharField(max_length=50, default="")
+    timestamp = models.DateTimeField(auto_now=True)
+
+class Status(models.Model):
+    key = models.CharField(max_length=50, default="")
+    status = models.CharField(max_length=30, default="")
+    detail = models.CharField(max_length=200, default="")
+    timestamp = models.DateTimeField(auto_now=True)

--- a/lilac3/scheduler/config.py
+++ b/lilac3/scheduler/config.py
@@ -1,0 +1,15 @@
+#!/bin/python
+
+if __name__ == '__main__':
+    import json
+    from common.options import Options
+
+    config = Options()
+
+    #config.ResouceGroupName.max_parallel = 20
+    config.default = 'GitHubActions'
+    config.GitHubActions.max_parallel = 20
+    config.x86_64.max_parallel = 1
+    config.arm.max_parallel = 1
+
+    print(json.dumps(config))

--- a/lilac3/scheduler/scheduler.py
+++ b/lilac3/scheduler/scheduler.py
@@ -1,0 +1,105 @@
+#!/bin/python
+def get_pkgbase(entry):
+    if type(entry) == dict:
+        return list(entry.keys())[0]
+    elif type(entry) == str:
+        return entry
+    else:
+        raise ValueError
+
+def add_edge(graph, source, target):
+    source = get_pkgbase(source)
+    target = get_pkgbase(target)
+    if not source in graph:
+        graph[source] = set()
+    graph[source].add(target)
+
+def recursively_fail(dependency_graph, reversed_dependency_graph, pkgbase, caller=None):
+    if pkgbase in dependency_graph:
+        del dependency_graph[pkgbase]
+        status = Status.objects.get(key=pkgbase)
+        if status.status == 'STALED':
+            status.status = 'ERROR'
+            status.detail = f'Dependency issue: {caller} .'
+            status.save()
+        if pkgbase in reversed_dependency_graph:
+            for i in reversed_dependency_graph[pkgbase]:
+                recursively_fail(dependency_graph, reversed_dependency_graph, i, caller=pkgbase)
+
+def recursively_skip(dependency_graph, reversed_dependency_graph, pkgbase, caller=None):
+    if pkgbase in dependency_graph:
+        if caller:
+            del dependency_graph[pkgbase]
+            status = Status.objects.get(key=pkgbase)
+            if status.status == 'STALED':
+                status.detail = f'Waiting for dependency: {caller} .'
+                status.save()
+        else:
+            caller = pkgbase
+        if pkgbase in reversed_dependency_graph:
+            for i in reversed_dependency_graph[pkgbase]:
+                recursively_skip(dependency_graph, reversed_dependency_graph, i, caller=caller)
+
+if __name__ == '__main__':
+    import logging
+    import json
+    import os
+    import sys
+    import traceback
+    import yaml
+    from graphlib import TopologicalSorter
+    from pathlib import Path
+    from datetime import datetime, timedelta
+    from tornado.log import enable_pretty_logging
+    from tornado.options import options
+    from recorder.models import Status
+
+    options.logging = 'debug'
+    logger = logging.getLogger()
+    enable_pretty_logging(options=options, logger=logger)
+
+    repository = Path(sys.argv[1])
+    dependency_graph = {}
+    reversed_dependency_graph = {}
+
+    for i in repository.rglob('lilac.yaml'):
+        try:
+            pkgbase = str(i.parent)[len(str(repository))+1:]
+            with open(i) as f:
+                lilac = yaml.safe_load(f)
+            if not 'repo_depends' in lilac:
+                add_edge(dependency_graph, pkgbase, 'dummy')
+                add_edge(reversed_dependency_graph, 'dummy', pkgbase)
+            else:
+                for j in lilac['repo_depends']:
+                    add_edge(dependency_graph, pkgbase, j)
+                    add_edge(reversed_dependency_graph, j, pkgbase)
+            logger.debug(f'Loaded %s', pkgbase)
+        except:
+            logger.error(f'Failed to load %s', pkgbase)
+            traceback.print_exc()
+
+    failed = [i.key for i in Status.objects.filter(status='ERROR')]
+    for i in failed:
+        recursively_fail(dependency_graph, reversed_dependency_graph, i)
+
+    staled = [i.key for i in Status.objects.filter(status='STALED')]
+    for i in staled:
+        recursively_skip(dependency_graph, reversed_dependency_graph, i)
+
+    staled = [i.key for i in Status.objects.filter(status='BUILDING')]
+    for i in staled:
+        recursively_skip(dependency_graph, reversed_dependency_graph, i)
+
+    sorter = TopologicalSorter(dependency_graph)
+    order = list(sorter.static_order())
+    order = [i for i in order if i in staled]
+
+    resources = json.loads(os.environ['SCHEDULER_RESOURCE'])
+
+    for group in resources.keys():
+        resources[group]['used'] = Status.objects.count(detail__startswith(group))
+
+    for i in order:
+        # TODO
+        # Build i if i.group.used < i.group.max_parellel

--- a/lilac3/seeker/aliases.yaml
+++ b/lilac3/seeker/aliases.yaml
@@ -1,0 +1,54 @@
+python:
+  source: archpkg
+  archpkg: python
+  from_pattern: '^(\d+\.\d+)\..*'
+  to_pattern: '\1'
+ruby:
+  source: archpkg
+  archpkg: ruby
+  from_pattern: ^(\d+\.\d+)\..*
+  to_pattern: \1
+perl:
+  source: archpkg
+  archpkg: perl
+  from_pattern: ^(\d+\.\d+)\..*
+  to_pattern: \1
+boost:
+  source: archpkg
+  archpkg: boost-libs
+  from_pattern: ^(\d+\.\d+)\..*
+  to_pattern: \1
+icu:
+  source: archpkg
+  archpkg: icu
+  from_pattern: ^(\d+)\..*
+  to_pattern: \1
+readline:
+  source: archpkg
+  archpkg: readline
+  from_pattern: ^(\d+)\..*
+  to_pattern: \1
+clang:
+  source: archpkg
+  archpkg: clang
+  from_pattern: ^(\d+)\..*
+  to_pattern: \1
+protobuf:
+  source: archpkg
+  archpkg: protobuf
+  provided: libprotobuf.so
+  strip_release: true
+jsoncpp:
+  source: archpkg
+  archpkg: jsoncpp
+  provided: libjsoncpp.so
+  strip_release: true
+mediawiki:
+  source: archpkg
+  archpkg: mediawiki
+  from_pattern: '^(\d+\.\d+)\..*'
+  to_pattern: '\1'
+alpm-lilac:
+  source: alpm
+  dbpath: '{pacman_db_dir}'
+  repo: '{repo_name}'

--- a/lilac3/seeker/collect.py
+++ b/lilac3/seeker/collect.py
@@ -1,0 +1,46 @@
+#!/bin/python
+
+if __name__ == '__main__':
+    import logging
+    import sys
+    import traceback
+    from pathlib import Path
+    import yaml
+    import toml
+    from tornado.log import enable_pretty_logging
+    from tornado.options import options
+    from common.options import Options
+
+    options.logging = 'debug'
+    logger = logging.getLogger()
+    enable_pretty_logging(options=options, logger=logger)
+
+    repository = Path(sys.argv[1])
+
+    with open(Path(__file__).parent / 'aliases.yaml') as f:
+        aliases = yaml.safe_load(f)
+
+    config = Options()
+    config.__config__.oldver = '/dev/null'
+    config.__config__.newver = 'newver.json'
+
+    for i in repository.rglob('lilac.yaml'):
+        try:
+            pkgbase = str(i.parent)[len(str(repository))+1:]
+            with open(i) as f:
+                lilac = yaml.safe_load(f)
+            for j, update_on in enumerate(lilac['update_on']):
+                if 'alias' in update_on.keys():
+                    config[f'{pkgbase}:{j}'] = aliases[update_on['alias']]
+                else:
+                    for key, value in update_on.items():
+                        if value is None:
+                            update_on[key] = i.parent.name
+                    config[f'{pkgbase}:{j}'] = update_on
+            logger.debug('Loaded %s', pkgbase)
+        except:
+            logger.error(f'Failed to load %s', pkgbase)
+            traceback.print_exc()
+
+    with open('nvchecker.toml', 'w') as f:
+        toml.dump(config, f)

--- a/lilac3/seeker/seeker.yml
+++ b/lilac3/seeker/seeker.yml
@@ -1,0 +1,1 @@
+../../.github/workflows/seeker.yml

--- a/lilac3/seeker/trigger.py
+++ b/lilac3/seeker/trigger.py
@@ -1,0 +1,12 @@
+#!/bin/python
+
+if __name__ == '__main__':
+    import sys
+    from recorder.models import Status
+
+    pkgbase = sys.argv[1]
+    print(f'Marking {pkgbase} as staled')
+    status = Status.objects.get(key=pkgbase)
+    if not status.status == 'STALED':
+        status.status = 'STALED'
+        status.save()

--- a/lilac3/seeker/trigger.yml
+++ b/lilac3/seeker/trigger.yml
@@ -1,0 +1,1 @@
+../../.github/workflows/trigger.yml

--- a/lilac3/seeker/update.py
+++ b/lilac3/seeker/update.py
@@ -1,0 +1,50 @@
+#!/bin/python
+
+if __name__ == '__main__':
+    import os
+    import sys
+    import json
+    import logging
+    from datetime import datetime, timedelta
+    from tornado.log import enable_pretty_logging
+    from tornado.options import options
+    from recorder.models import Status, Version
+    from django.db.models import F
+
+    options.logging = 'debug'
+    logger = logging.getLogger()
+    enable_pretty_logging(options=options, logger=logger)
+
+    with open('newver.json') as f:
+        newver = json.load(f)
+
+    logger.info('Updating newver')
+    for key, value in newver.items():
+        try:
+            record = Version.objects.get(key=key)
+        except Version.DoesNotExist:
+            record = Version(key=key)
+        if record.newver != value:
+            record.newver = value
+            record.save()
+
+    logger.info('Marking staled')
+
+    for record in Version.objects.exclude(newver__exact=F('oldver')):
+        key = record.key[:record.key.find(':')]
+        try:
+            status = Status.objects.get(key=key)
+        except Status.DoesNotExist:
+            status = Status(key=key)
+
+        if status.status in ['', 'PUBLISHED']:
+            status.status = 'STALED'
+            status.save()
+        elif status.status == 'ERROR' and datetime.now() - status.timestamp > timedelta(days=1):
+            status.status = 'STALED'
+            status.save()
+
+        if status.status == 'STALED':
+            logger.debug(f'{key}: {record.oldver} -> {record.newver}')
+        else:
+            logger.debug(f'{key}: {status.status} on {status.timestamp}')


### PR DESCRIPTION
#145 #149 #159

### lilac 3
首先 lilac 3 就是我想的分拆后的下一代 lilac 。
所有代码执行寄托于 github actions ，这样所有运行的 log 都是透明的。邮件系统可以大幅度简化。
同时 github actions 可以写死很多变量，配置也可以大幅度简化。

主要模块包括：
* seeker: 查找 new version
* scheduler: 规划打包顺序，资源调度。
* packager: 打包。运行在 github 的默认 runner 和 self-hosted runner
* publisher: 接收打包结果，签名，更新 pacman db ，推送至存储
* poster: 每天发送一封邮件给每位 maintainer ，告知其有问题包的状态及对应 github actions run 的 log 链接。
* cleaner: 移除被删除的包。

合并是还没打算合并的。。。可以等其他的模块都搞定了的。现在就是来征求一下意见。。。

### seeker
seeker 是 lilac 3 第一个模块，内容即从 lilac.yaml 中收集 nvchecker 信息，生成 nvchecker.toml 。
最后执行 nvchecker 得到 newver.json 并传输至 artifacts 。

#### 配置
配置 secrets.REPOSITORY 即可运行。

#### 执行预览
![seeker](https://github.com/petronny/lilac/workflows/seeker/badge.svg)
在 https://github.com/petronny/lilac/runs/1558298622?check_suite_focus=true
log 可以帮助大家了解报错情况，不用再发邮件了。

#### 附注
* 考虑了多层目录的结构，rglob 性能的问题在 github actions 的干净环境下就不存在了。
* 目前是手动触发的，我想的是大家 fork 一下，然后自行根据需求填写自动触发方案。