### PR TITLE
add --force-local when calling tar

### DIFF
--- a/lilac2/api.py
+++ b/lilac2/api.py
@@ -561,7 +561,7 @@ def check_library_provides() -> None:
   provides_pattern = re.compile(r'^provides = .*\.so$')
   pkgs = [n for n in os.listdir() if pkg_pattern.search(n)]
   for pkg in pkgs:
-    pkginfo = run_cmd(['tar', 'xOf', pkg, '.PKGINFO'])
+    pkginfo = run_cmd(['tar', '--force-local', 'xOf', pkg, '.PKGINFO'])
     for line in pkginfo.splitlines():
       if provides_pattern.match(line):
         raise Exception(f'{pkg} has an unversioned library "provides" entry: {line[11:]}')


### PR DESCRIPTION
This fixes "Cannot connect to xxx: resolve failed" errors when working
with file names with colons (e.g. a package with an epoch).