### PR TITLE
Update Dependencies of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Python libraries
 * pyalpm
 * structlog
 * prctl
+* chardet
 
 Setup
 ----


### PR DESCRIPTION
If this dependence is not added, an error report
```
Traceback (most recent call last):
  File "/usr/bin/lilac", line 33, in <module>
    from lilac2.packages import (
  File "/usr/lib/python3.9/site-packages/lilac2/packages.py", line 11, in <module>
    from .api import run_cmd
  File "/usr/lib/python3.9/site-packages/lilac2/api.py", line 19, in <module>
    import requests
  File "/usr/lib/python3.9/site-packages/requests/__init__.py", line 44, in <module>
    import chardet
ModuleNotFoundError: No module named 'chardet'
```