### PR TITLE
recv_gpg_keys: fix running under systemd services

### DIFF
--- a/recv_gpg_keys
+++ b/recv_gpg_keys
@@ -1,8 +1,9 @@
 #!/bin/bash -e
 
 if [[ -z $SANDBOXED ]]; then
+  [[ -d /run/user/$UID/gnupg ]] && bind_gnupg=("--ro-bind" "/run/user/$UID/gnupg" "/run/user/$UID/gnupg")
   exec bwrap --unshare-all --ro-bind / / --tmpfs /home --tmpfs /tmp \
-    --tmpfs /run --ro-bind /run/user/$UID/gnupg /run/user/$UID/gnupg \
+    --tmpfs /run "${bind_gnupg[@]}" \
     --proc /proc --dev /dev --die-with-parent \
     --ro-bind "$0" /tmp/recv_gpg_keys \
     --bind ~/.lilac/gnupg "$HOME/.gnupg" \


### PR DESCRIPTION
/run/user is not accessible when lilac is running as (part of) a systemd
service with `ProtectHome=yes`: (ex: buildbot-worker@.service [1])

> bwrap: Can't find source path /run/user/979/gnupg: Permission denied

[1] https://github.com/buildbot/buildbot-contrib/blob/master/worker/contrib/systemd/buildbot-worker%40.service