### PR TITLE
build-cleaner: fix deletion of btrfs subvolume with nested subvolumes in coreutils >= 9.2

### DIFF
--- a/scripts/build-cleaner
+++ b/scripts/build-cleaner
@@ -56,7 +56,9 @@ def drop_chroot(full_path):
         try:
             subprocess.check_call(['btrfs', 'subvolume', 'delete', full_path], stdout=subprocess.DEVNULL)
         except subprocess.CalledProcessError: # nested subvolumes
-            subprocess.check_call(['rm', '-rf', '--one-file-system', full_path])
+            # rm in coreutils >= 9.2 treat nested subvolumn as on another file system
+            # and specifying "--one-file-system" flag would cause rm to return non-zero
+            subprocess.check_call(['rm', '-rf', full_path])
     else:
         subprocess.check_call(['rm', '-rf', '--one-file-system', full_path])
 


### PR DESCRIPTION
在 coreutils >= 9.2 后 `--one-file-system` 会导致 `rm` 跳过如下systemd创建的 "./portables" "./machines" subvolume 而返回非0，导致 `check_call` 抛出了另一个未拦截的 `CalledProcessError`
```
$ btrfs subvolume list /
ID xxx0 gen xxxxx0 top level 256 path var/lib/archbuild/multilib-x86_64/lilac-0
ID xxx1 gen xxxxx1 top level 1290 path var/lib/archbuild/multilib-x86_64/lilac-0/var/lib/portables
ID xxx2 gen xxxxx2 top level 1290 path var/lib/archbuild/multilib-x86_64/lilac-0/var/lib/machines
```

```
rm: 跳过 '/var/lib/archbuild/extra-x86_64/lilac-0/var/lib/portables'，因为它位于另一个设备上
rm: 跳过 '/var/lib/archbuild/extra-x86_64/lilac-0/var/lib/machines'，因为它位于另一个设备上
```

去掉 `--one-file-system` 以解决此问题。当然也用可以 `subprocess.call()` 而不检查返回值，但我不觉得 `--one-file-system` 在这里有什么作用