### PR TITLE
Implement rpkgs nvchecker source for CRAN and Bioconductor

### DIFF
--- a/nvchecker_source/README.rst
+++ b/nvchecker_source/README.rst
@@ -16,3 +16,20 @@ use_max_tag
 This source supports `list options`_ when ``use_max_tag`` is set.
 
 .. _list options: https://github.com/lilydjwg/nvchecker#list-options
+
+R packages from CRAN and Bioconductor
+-------------------------------------
+::
+
+  source = "rpkgs"
+
+Check versions from CRAN and Bioconductor. This source is optimized for checking large amounts of packages at once. If you want to check only a few, the ``cran`` source is better for CRAN packages.
+
+pkgname
+  Name of the R package.
+
+repo
+  The repo of the package. Possible values are ``cran``, ``bioc``, ``bioc-data-annotation``, ``bioc-data-experiment`` and ``bioc-workflows``.
+
+md5
+  If set to ``true``, a ``#`` character and the md5sum of the source archive is appended to the version. Defaults to ``false``.

--- a/nvchecker_source/rpkgs.py
+++ b/nvchecker_source/rpkgs.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Tuple
 from zlib import decompress
 
 from nvchecker.api import GetVersionError, session
@@ -21,7 +21,7 @@ PKG_FLEN = len(PKG_FIELD)
 VER_FLEN = len(VER_FIELD)
 MD5_FLEN = len(MD5_FIELD)
 
-async def get_versions(repo: str) -> Dict[str, str]:
+async def get_versions(repo: str) -> Dict[str, Tuple[str, str]]:
   url = URL_MAP.get(repo)
   if url is None:
     raise GetVersionError(f'Unknown repo {repo}')

--- a/nvchecker_source/rpkgs.py
+++ b/nvchecker_source/rpkgs.py
@@ -1,0 +1,56 @@
+from typing import Dict
+from zlib import decompress
+
+from nvchecker.api import GetVersionError, session
+
+BIOC_TEMPLATE = 'https://bioconductor.org/packages/release/%s/src/contrib/PACKAGES.gz'
+
+URL_MAP = {
+  'cran': 'https://cran.r-project.org/src/contrib/PACKAGES.gz',
+  'bioc': BIOC_TEMPLATE % 'bioc',
+  'bioc-data-annotation': BIOC_TEMPLATE % 'data/annotation',
+  'bioc-data-experiment': BIOC_TEMPLATE % 'data/experiment',
+  'bioc-workflows': BIOC_TEMPLATE % 'workflows',
+}
+
+PKG_FIELD = b'Package: '
+VER_FIELD = b'Version: '
+MD5_FIELD = b'MD5sum: '
+
+PKG_FLEN = len(PKG_FIELD)
+VER_FLEN = len(VER_FIELD)
+MD5_FLEN = len(MD5_FIELD)
+
+async def get_versions(repo: str) -> Dict[str, str]:
+  url = URL_MAP.get(repo)
+  if url is None:
+    raise GetVersionError(f'Unknown repo {repo}')
+  res = await session.get(url)
+  data = decompress(res.body, wbits = 31)
+
+  result = {}
+  for section in data.split(b'\n\n'):
+    pkg = ver = md5 = None
+    for line in section.split(b'\n'):
+      if line.startswith(PKG_FIELD):
+        pkg = line[PKG_FLEN:].decode('utf8')
+      elif line.startswith(VER_FIELD):
+        ver = line[VER_FLEN:].decode('utf8')
+      elif line.startswith(MD5_FIELD):
+        md5 = line[MD5_FLEN:].decode('utf8')
+    if pkg is None or ver is None or md5 is None:
+      raise GetVersionError('Invalid package data', pkg = pkg, ver = ver, md5 = md5)
+    result[pkg] = (ver, md5)
+
+  return result
+
+async def get_version(name, conf, *, cache, **kwargs):
+  pkgname = conf.get('pkgname', name)
+  repo = conf['repo']
+  versions = await cache.get(repo, get_versions)
+  data = versions.get(pkgname)
+  if data is None:
+    raise GetVersionError(f'Package {pkgname} not found in repo {repo}')
+  add_md5 = conf.get('md5', False)
+  ver, md5 = data
+  return f'{ver}#{md5}' if add_md5 else ver

--- a/nvchecker_source/rpkgs.py
+++ b/nvchecker_source/rpkgs.py
@@ -24,7 +24,7 @@ MD5_FLEN = len(MD5_FIELD)
 async def get_versions(repo: str) -> Dict[str, Tuple[str, str]]:
   url = URL_MAP.get(repo)
   if url is None:
-    raise GetVersionError(f'Unknown repo {repo}')
+    raise GetVersionError('Unknown repo', repo = repo)
   res = await session.get(url)
   data = decompress(res.body, wbits = 31)
 

--- a/tests/test_rpkgs.py
+++ b/tests/test_rpkgs.py
@@ -1,0 +1,81 @@
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+pytestmark = pytest.mark.asyncio
+
+from nvchecker import core, __main__ as main
+from nvchecker.util import Entries, VersData, RawResult
+
+async def run(entries: Entries) -> VersData:
+  task_sem = asyncio.Semaphore(20)
+  result_q: asyncio.Queue[RawResult] = asyncio.Queue()
+  keymanager = core.KeyManager(None)
+
+  dispatcher = core.setup_httpclient()
+  entry_waiter = core.EntryWaiter()
+  futures = dispatcher.dispatch(
+    entries, task_sem, result_q,
+    keymanager, entry_waiter, 1, {},
+  )
+
+  oldvers: VersData = {}
+  result_coro = core.process_result(oldvers, result_q, entry_waiter)
+  runner_coro = core.run_tasks(futures)
+
+  vers, _has_failures = await main.run(result_coro, runner_coro)
+  return vers
+
+@pytest_asyncio.fixture(scope='module')
+async def get_version():
+  async def __call__(name, config):
+    entries = {name: config}
+    newvers = await run(entries)
+    return newvers.get(name)
+
+  return __call__
+
+loop = asyncio.new_event_loop()
+@pytest.fixture(scope='module')
+def event_loop(request):
+  yield loop
+  loop.close()
+
+
+async def test_cran(get_version):
+  assert await get_version('xml2', {
+    'source': 'rpkgs',
+    'pkgname': 'xml2',
+    'repo': 'cran',
+    'md5': True,
+  }) == '1.3.4#1921b6cba1051577019d190895dbaeb4'
+
+async def test_bioc(get_version):
+  assert await get_version('BiocVersion', {
+    'source': 'rpkgs',
+    'pkgname': 'BiocVersion',
+    'repo': 'bioc',
+  }) == '3.17.1'
+
+async def test_bioc_data_annotation(get_version):
+  assert await get_version('GO.db', {
+    'source': 'rpkgs',
+    'pkgname': 'GO.db',
+    'repo': 'bioc-data-annotation',
+  }) == '3.17.0'
+
+async def test_bioc_data_experiment(get_version):
+  assert await get_version('ALL', {
+    'source': 'rpkgs',
+    'pkgname': 'ALL',
+    'repo': 'bioc-data-experiment',
+  }) == '1.42.0'
+
+async def test_bioc_workflows(get_version):
+  assert await get_version('liftOver', {
+    'source': 'rpkgs',
+    'pkgname': 'liftOver',
+    'repo': 'bioc-workflows',
+    'md5': True,
+  }) == '1.24.0#ac7f9d6cd479fa829c7b26088297d882'


### PR DESCRIPTION
This source fetches and caches the `PACKAGES.gz` file of the repo.

Optimized and expanded from lilydjwg/nvchecker#184