### PR TITLE
Add support for repo_makedepends configuration in lilac.yaml

### DIFF
--- a/lilac
+++ b/lilac
@@ -65,6 +65,7 @@ MYNAME = config['lilac']['name']
 
 nvdata: dict[str, NvResults] = {}
 DEPMAP: dict[str, set[Dependency]] = {}
+BUILD_DEPMAP: dict[str, set[Dependency]] = {}
 build_reasons: DefaultDict[str, list[BuildReason]] = defaultdict(list)
 
 logger = logging.getLogger(__name__)
@@ -365,7 +366,7 @@ def build_it(
     update_info = nvdata[pkg],
     bindmounts = repo.bindmounts,
     tmpfs = repo.tmpfs,
-    depends = DEPMAP.get(pkg, ()),
+    depends = BUILD_DEPMAP.get(pkg, ()),
     repo = REPO,
     myname = MYNAME,
     destdir = DESTDIR,
@@ -505,7 +506,7 @@ def main_may_raise(
   failed = REPO.load_managed_lilac_and_report()
 
   depman = DependencyManager(REPO.repodir)
-  DEPMAP = get_dependency_map(depman, REPO.lilacinfos)
+  DEPMAP, BUILD_DEPMAP = get_dependency_map(depman, REPO.lilacinfos)
 
   # packages we care about
   care_pkgs: set[str] = set()

--- a/lilac
+++ b/lilac
@@ -308,7 +308,7 @@ def try_pick_some(
 
     if rs := build_reasons.get(pkg):
       if len(rs) == 1 and isinstance(rs[0], BuildReason.FailedByDeps):
-        ds = DEPMAP[pkg]
+        ds = BUILD_DEPMAP[pkg]
         if not all(d.resolve() for d in ds):
           buildsorter.done(pkg)
           if db.USE:
@@ -485,7 +485,7 @@ def setup_thread():
 def main_may_raise(
   D: dict[str, Any], pkgs_from_args: List[str], logdir: Path,
 ) -> None:
-  global DEPMAP
+  global DEPMAP, BUILD_DEPMAP
 
   if get_git_branch() not in ['master', 'main']:
     raise Exception('repo not on master or main, aborting.')

--- a/lilac2/lilacyaml.py
+++ b/lilac2/lilacyaml.py
@@ -51,6 +51,13 @@ def load_lilac_yaml(dir: Path) -> dict[str, Any]:
         depends[i] = next(iter(entry.items()))
       else:
         depends[i] = entry, entry
+  makedepends = conf.get('repo_makedepends')
+  if makedepends:
+    for i, entry in enumerate(makedepends):
+      if isinstance(entry, dict):
+        makedepends[i] = next(iter(entry.items()))
+      else:
+        makedepends[i] = entry, entry
 
   for func in FUNCTIONS:
     name = conf.get(func)
@@ -92,6 +99,7 @@ def load_lilacinfo(dir: Path) -> LilacInfo:
     update_on_build = [OnBuildEntry(**x) for x in yamlconf.get('update_on_build', [])],
     throttle_info = throttle_info,
     repo_depends = yamlconf.get('repo_depends', []),
+    repo_makedepends = yamlconf.get('repo_makedepends', []),
     time_limit_hours = yamlconf.get('time_limit_hours', 1),
     staging = yamlconf.get('staging', False),
     managed = yamlconf.get('managed', True),

--- a/lilac2/packages.py
+++ b/lilac2/packages.py
@@ -15,25 +15,44 @@ from . import lilacyaml
 
 def get_dependency_map(
   depman: DependencyManager, lilacinfos: LilacInfos,
-) -> Dict[str, Set[Dependency]]:
+) -> Tuple[Dict[str, Set[Dependency]], Dict[str, Set[Dependency]]]:
   '''compute ordered, complete dependency relations between pkgbases (the directory names)
 
   This function does not make use of pkgname because they maybe the same for
   different pkgdir. Those are carried by Dependency and used elsewhere.
+
+  The first returned dict has the complete set of dependencies of the given pkgbase, including
+  build-time dependencies of other dependencies. The second dict has only the dependnecies
+  required to be installed in the build chroot. For example, if A depends on B, and B makedepends
+  on C, then the first dict has "A: {B, C}" while the second dict has only "A: {B}".
   '''
   map: DefaultDict[str, Set[Dependency]] = defaultdict(set)
   pkgdir_map: DefaultDict[str, Set[str]] = defaultdict(set)
   rmap: DefaultDict[str, Set[str]] = defaultdict(set)
 
-  for pkgbase, info in lilacinfos.items():
-    depends = info.repo_depends
+  # same as above maps, but contain only normal dependencies, not makedepends or checkdepends
+  norm_map: DefaultDict[str, Set[Dependency]] = defaultdict(set)
+  norm_pkgdir_map: DefaultDict[str, Set[str]] = defaultdict(set)
+  norm_rmap: DefaultDict[str, Set[str]] = defaultdict(set)
 
-    ds = [depman.get(d) for d in depends]
-    if ds:
-      for d in ds:
-        pkgdir_map[pkgbase].add(d.pkgdir.name)
-        rmap[d.pkgdir.name].add(pkgbase)
-      map[pkgbase].update(ds)
+  for pkgbase, info in lilacinfos.items():
+    for d in info.repo_depends:
+      d = depman.get(d)
+
+      pkgdir_map[pkgbase].add(d.pkgdir.name)
+      rmap[d.pkgdir.name].add(pkgbase)
+      map[pkgbase].add(d)
+
+      norm_pkgdir_map[pkgbase].add(d.pkgdir.name)
+      norm_rmap[d.pkgdir.name].add(pkgbase)
+      norm_map[pkgbase].add(d)
+
+    for d in info.repo_makedepends:
+      d = depman.get(d)
+
+      pkgdir_map[pkgbase].add(d.pkgdir.name)
+      rmap[d.pkgdir.name].add(pkgbase)
+      map[pkgbase].add(d)
 
   dep_order = graphlib.TopologicalSorter(pkgdir_map).static_order()
   for pkgbase in dep_order:
@@ -42,8 +61,21 @@ def get_dependency_map(
       dependers = rmap[pkgbase]
       for dd in dependers:
         map[dd].update(deps)
+    if pkgbase in norm_rmap:
+      deps = norm_map[pkgbase]
+      dependers = norm_rmap[pkgbase]
+      for dd in dependers:
+        norm_map[dd].update(deps)
 
-  return map
+  build_dep_map: DefaultDict[str, Set[Dependency]] = defaultdict(set)
+  for pkgbase, info in lilacinfos.items():
+    build_deps = build_dep_map[pkgbase]
+    build_deps.update(norm_map[pkgbase])
+    for d in info.repo_makedepends:
+      build_deps.add(depman.get(d))
+      build_deps.update(norm_map[d])
+
+  return map, build_dep_map
 
 _DependencyTuple = namedtuple(
   '_DependencyTuple', 'pkgdir pkgname')
@@ -70,8 +102,7 @@ class Dependency(_DependencyTuple):
     elif not pkgs:
       return None
     else:
-      ret = sorted(
-        pkgs, reverse=True, key=lambda x: x.stat().st_mtime)[0]
+      ret = max(pkgs, key=lambda x: x.stat().st_mtime)
       return ret
 
 class DependencyManager:

--- a/lilac2/packages.py
+++ b/lilac2/packages.py
@@ -72,8 +72,9 @@ def get_dependency_map(
     build_deps = build_dep_map[pkgbase]
     build_deps.update(norm_map[pkgbase])
     for d in info.repo_makedepends:
-      build_deps.add(depman.get(d))
-      build_deps.update(norm_map[d])
+      d = depman.get(d)
+      build_deps.add(d)
+      build_deps.update(norm_map[d.pkgdir.name])
 
   return map, build_dep_map
 

--- a/lilac2/typing.py
+++ b/lilac2/typing.py
@@ -35,6 +35,7 @@ class LilacInfo:
   update_on_build: list[OnBuildEntry]
   throttle_info: dict[int, datetime.timedelta]
   repo_depends: list[tuple[str, str]]
+  repo_makedepends: list[tuple[str, str]]
   time_limit_hours: float
   staging: bool
   managed: bool

--- a/schema-docs/lilac-yaml-schema.yaml
+++ b/schema-docs/lilac-yaml-schema.yaml
@@ -36,7 +36,20 @@ properties:
     description: Time limit in hours. The build will be aborted if it doesn't finish in time. Default is one hour.
     type: number
   repo_depends:
-    description: Packages in the repo to be built and installed before building the current package.
+    description: Packages in the repo that are direct dependencies of the current package.
+    type: array
+    items:
+      anyOf:
+        - type: string
+          description: Package (directory) name
+        - type: object
+          description: Package base (directory) as key and package name as value
+          minProperties: 1
+          maxProperties: 1
+          additionalProperties:
+            type: string
+  repo_makedepends:
+    description: Packages in the repo that are in makedepends or checkdepends of the current package.
     type: array
     items:
       anyOf:

--- a/tests/test_dependency_resolution.py
+++ b/tests/test_dependency_resolution.py
@@ -1,0 +1,41 @@
+from collections import namedtuple
+from pathlib import Path
+
+from lilac2.packages import DependencyManager, get_dependency_map
+
+def test_dependency_map():
+  depman = DependencyManager(Path('.'))
+  Info = namedtuple('Info', ['repo_depends', 'repo_makedepends'])
+  lilacinfos = {
+    'A': Info(['B'], ['C']),
+    'B': Info(['D'], ['C']),
+    'C': Info([],    ['E']),
+    'D': Info([],    []),
+    'E': Info(['D'], []),
+    'F': Info([],    ['C', 'D']),
+    'G': Info([],    ['F']),
+  }
+  expected_all = {
+    'A': { 'B', 'C', 'D', 'E' },
+    'B': { 'C', 'D', 'E' },
+    'C': { 'D', 'E' },
+    'D': set(),
+    'E': { 'D' },
+    'F': { 'C', 'D', 'E' },
+    'G': { 'C', 'D', 'E', 'F' },
+  }
+  expected_build = {
+    'A': { 'B', 'C', 'D' },
+    'B': { 'C', 'D' },
+    'C': { 'D', 'E' },
+    'D': set(),
+    'E': { 'D' },
+    'F': { 'C', 'D' },
+    'G': { 'F' },
+  }
+
+  res_all, res_build = get_dependency_map(depman, lilacinfos)
+  def parse_map(m):
+    return { key: { val.pkgdir.name for val in s } for key, s in m.items() }
+  assert parse_map(res_all) == expected_all
+  assert parse_map(res_build) == expected_build


### PR DESCRIPTION
`makedepends` and `checkdepends` of the package should be listed in repo_makedepends instead of repo_depends so that no unnecessary dependencies get installed in the build chroots.