### PR TITLE
[bugfix] avoid `more_pkgs` being updated during iteration

### DIFF
--- a/lilac
+++ b/lilac
@@ -583,15 +583,17 @@ def main_may_raise(
     for i in info.update_on_build:
       if_this_then_those[i.pkgbase].add(p)
   more_pkgs = set()
-  count = 0
   for p in build_reasons:
     if pkgs := if_this_then_those.get(p):
       more_pkgs.update(pkgs)
-  while len(more_pkgs) != count: # has new
-    count = len(more_pkgs)
+  while True:
+    add_to_more_pkgs = set()
     for p in more_pkgs:
       if pkgs := if_this_then_those.get(p):
-        more_pkgs.update(pkgs)
+        add_to_more_pkgs.update(pkgs)
+    if add_to_more_pkgs.issubset(more_pkgs):
+      break
+    more_pkgs.update(add_to_more_pkgs)
   for p in more_pkgs:
     update_on_build = REPO.lilacinfos[p].update_on_build
     build_reasons[p].append(BuildReason.OnBuild(update_on_build))


### PR DESCRIPTION
Previously, the set `more_pkgs` in function `main_may_raise` can be updated during iteration, which leads to `RuntimeError` and crashes lilac. The bug can be triggered when a package with `update_on_build` specified in lilac.yaml is referenced in another `update_on_build` array. This PR is a minimal refactor to fix the issue.