### PR TITLE
update_pkgrel: Allow non-UTF-8 encoding

### DIFF
--- a/lilac2/api.py
+++ b/lilac2/api.py
@@ -243,7 +243,7 @@ def update_pkgver_and_pkgrel(
 def update_pkgrel(
   rel: Optional[PkgRel] = None,
 ) -> None:
-  with open('PKGBUILD') as f:
+  with open('PKGBUILD', errors='replace') as f:
     pkgbuild = f.read()
 
   def replacer(m):


### PR DESCRIPTION
There are non-UTF-8 encoding in pacman-static, which leads to the following problems:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe1 in position 3045: invalid continuation byte
```