### PR TITLE
readthedocs: fix

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@ build:
   tools:
     python: "3.10"
 
+sphinx:
+  configuration: docs/conf.py
+
 python:
   install:
   - requirements: docs/requirements.txt


### PR DESCRIPTION
This commit fixes the `Missing Sphinx configuration key` [error](https://app.readthedocs.org/projects/lilac/builds/) caused by [Deprecation of projects using Sphinx or MkDocs without an explicit configuration file](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/).

Tested: https://app.readthedocs.org/projects/lilac-nya/builds/28154178/