### PR TITLE
Use tail to read logfile and print to terminal stderr

### DIFF
--- a/lilac
+++ b/lilac
@@ -832,12 +832,13 @@ def main(logdir: Path, pkgs_from_args: List[str]) -> None:
       msg = l10n.format_value('runtime-error-traceback') + '\n\n' + tb
       REPO.report_error(subject, msg)
 
-def setup() -> Path:
+def setup() -> tuple[Path, subprocess.Popen]:
   prctl.set_child_subreaper(1)
 
   logdir = mydir / 'log' / time.strftime('%Y-%m-%dT%H:%M:%S')
   logdir.mkdir(parents=True, exist_ok=True)
   logfile = logdir / 'lilac-main.log'
+  tail = subprocess.Popen(['tail', '-n', '+1', '-f', logfile], stdout=2, stderr=2)
   fd = os.open(logfile, os.O_WRONLY | os.O_CREAT, 0o644)
   os.dup2(fd, 1)
   os.dup2(fd, 2)
@@ -854,11 +855,15 @@ def setup() -> Path:
   setup_build_logger()
   os.chdir(REPO.repodir)
 
-  return logdir
+  return logdir, tail
 
 if __name__ == '__main__':
   try:
-    logdir = setup()
+    logdir, tail = setup()
     main(logdir, sys.argv[1:])
+
+    if tail.poll() is None:
+      tail.terminate()
+      tail.wait()
   except Exception:
     logger.exception('unexpected error')


### PR DESCRIPTION
I think printing logs directly helps user to monitor the process and debug. For example, with this, when I trigger a lilac build in GitHub Actions, I can tell what lilac is doing and whether there is a fail.

This the easiest way I know to achieve this. It's not perfect. In my test, it always don't print the last `git push`'s output:

```bash
...
[D 06-30 13:23:27.715 cmd:88] running ['git', 'push'], not using pty, showing output
# no this line below
Everything up-to-date
```

Even I sleep 5s before terminating `tail`. I don't know why exactly, but I think it's fine for now.

I also searched some other solutions, like [python - How to duplicate sys.stdout to a log file? - Stack Overflow](https://stackoverflow.com/questions/616645/how-to-duplicate-sys-stdout-to-a-log-file). But it seems not working with subprocess command because it doesn't duplicate the logfile descriptor.