### PR TITLE
set PACKAGE_FILES environment variable for postbuild commands

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -75,7 +75,7 @@ postrun = [
 ]
 
 # run some commands after each package built
-# env: PKGBASE, RESULT=successful, failed, skipped, staged, VERSION
+# env: PKGBASE, RESULT=successful, failed, skipped, staged, VERSION, PACKAGE_FILES
 # postbuild = [
 #   [...]
 # ]

--- a/lilac2/repo.py
+++ b/lilac2/repo.py
@@ -18,6 +18,7 @@ import structlog
 from .vendor.github import GitHub
 
 from .mail import MailService
+from .packages import get_built_package_files
 from .tools import ansi_escape_re
 from . import api, lilacyaml, intl
 from .typing import LilacMod, Maintainer, LilacInfos, LilacInfo
@@ -366,10 +367,13 @@ class Repo:
     if not self.on_built_cmds:
       return
 
+    package_files = [f.name for f in get_built_package_files(self.repodir / pkg)]
     env = os.environ.copy()
     env['PKGBASE'] = pkg
     env['RESULT'] = result.__class__.__name__
     env['VERSION'] = version or ''
+    env['PACKAGE_FILES'] = ' '.join(package_files)
+
     for cmd in self.on_built_cmds:
       try:
         subprocess.check_call(cmd, env=env)


### PR DESCRIPTION
I'm trying to use `repo-add` to update my repo db after build, so I want to know file names of the new built package files. Writing a script to find them is a little diffcult, but lilac has a simple API to do it! So I made this change, `PACKAGE_FILES` are space-seperated file names and their parent paths are stripped because the final file path may be `destdir` or staging dir.

I think this is a good adition to post scripts, for example, I can now use a simple script below to add new packages:

```sh
for i in $PACKAGE_FILES; do
  repo-add /path/to/repo.db "$destdir/$i"
done
```