### PR TITLE
update tests

### DIFF
--- a/tests/test_rpkgs.py
+++ b/tests/test_rpkgs.py
@@ -44,7 +44,7 @@ async def test_cran(get_version):
     'pkgname': 'xml2',
     'repo': 'cran',
     'md5': True,
-  }) == '1.3.8#1864349a22fb93276bd7c5e87ade8287'
+  }) == '1.4.0#600d56c3da21eebac91416ef0f5e51ff'
 
 async def test_bioc(get_version):
   assert await get_version('BiocVersion', {


### PR DESCRIPTION
this commit fixes the following issue
```
[root@1fe422d45ee0 workspace]# pytest
====================================================================== test session starts ======================================================================
platform linux -- Python 3.13.7, pytest-8.4.1, pluggy-1.6.0
rootdir: /workspace
configfile: pytest.ini
plugins: anyio-4.10.0, asyncio-0.26.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=session, asyncio_default_test_loop_scope=function
collected 24 items                                                                                                                                              

tests/test_api.py .............                                                                                                                           [ 54%]
tests/test_dependency_resolution.py .                                                                                                                     [ 58%]
tests/test_lilaclib.py .....                                                                                                                              [ 79%]
tests/test_rpkgs.py F....                                                                                                                                 [100%]

=========================================================================== FAILURES ============================================================================
___________________________________________________________________________ test_cran ___________________________________________________________________________

get_version = <function get_version.<locals>.__call__ at 0x75a70f08e8e0>

    async def test_cran(get_version):
>     assert await get_version('xml2', {
        'source': 'rpkgs',
        'pkgname': 'xml2',
        'repo': 'cran',
        'md5': True,
      }) == '1.3.8#1864349a22fb93276bd7c5e87ade8287'
E     AssertionError: assert '1.4.0#600d56...416ef0f5e51ff' == '1.3.8#186434...7c5e87ade8287'
E       
E       - 1.3.8#1864349a22fb93276bd7c5e87ade8287
E       + 1.4.0#600d56c3da21eebac91416ef0f5e51ff

tests/test_rpkgs.py:42: AssertionError
--------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------
2025-08-25 01:42:40 [info     ] updated                        [nvchecker.core] name=xml2 old_version=None revision=None url=None version=1.4.0#600d56c3da21eebac91416ef0f5e51ff
==================================================================== short test summary info ====================================================================
FAILED tests/test_rpkgs.py::test_cran - AssertionError: assert '1.4.0#600d56...416ef0f5e51ff' == '1.3.8#186434...7c5e87ade8287'
================================================================= 1 failed, 23 passed in 5.22s ==================================================================
```