### PR TITLE
update tests

### DIFF
--- a/tests/test_rpkgs.py
+++ b/tests/test_rpkgs.py
@@ -44,28 +44,28 @@ async def test_cran(get_version):
     'pkgname': 'xml2',
     'repo': 'cran',
     'md5': True,
-  }) == '1.4.0#600d56c3da21eebac91416ef0f5e51ff'
+  }) == '1.4.1#72615e3ac78acae253ce195d0045a800'
 
 async def test_bioc(get_version):
   assert await get_version('BiocVersion', {
     'source': 'rpkgs',
     'pkgname': 'BiocVersion',
     'repo': 'bioc',
-  }) == '3.21.1'
+  }) == '3.22.0'
 
 async def test_bioc_data_annotation(get_version):
   assert await get_version('GO.db', {
     'source': 'rpkgs',
     'pkgname': 'GO.db',
     'repo': 'bioc-data-annotation',
-  }) == '3.21.0'
+  }) == '3.22.0'
 
 async def test_bioc_data_experiment(get_version):
   assert await get_version('ALL', {
     'source': 'rpkgs',
     'pkgname': 'ALL',
     'repo': 'bioc-data-experiment',
-  }) == '1.50.0'
+  }) == '1.52.0'
 
 async def test_bioc_workflows(get_version):
   ver = await get_version('liftOver', {


### PR DESCRIPTION
this commit fixes the following issue
```
==> Starting check()...
================================================================================================================================ test session starts =================================================================================================================================
platform linux -- Python 3.13.7, pytest-8.4.2, pluggy-1.6.0
rootdir: /tmp/lilac-git/src/lilac
configfile: pytest.ini
plugins: anyio-4.11.0, asyncio-0.26.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=session, asyncio_default_test_loop_scope=function
collected 24 items                                                                                                                                                                                                                                                                   

tests/test_api.py .............                                                                                                                                                                                                                                                [ 54%]
tests/test_dependency_resolution.py .                                                                                                                                                                                                                                          [ 58%]
tests/test_lilaclib.py .....                                                                                                                                                                                                                                                   [ 79%]
tests/test_rpkgs.py FFFF.                                                                                                                                                                                                                                                      [100%]

====================================================================================================================================== FAILURES ======================================================================================================================================
_____________________________________________________________________________________________________________________________________ test_cran ______________________________________________________________________________________________________________________________________

get_version = <function get_version.<locals>.__call__ at 0x7f74108254e0>

    async def test_cran(get_version):
>     assert await get_version('xml2', {
        'source': 'rpkgs',
        'pkgname': 'xml2',
        'repo': 'cran',
        'md5': True,
      }) == '1.4.0#600d56c3da21eebac91416ef0f5e51ff'
E     AssertionError: assert '1.4.1#72615e...e195d0045a800' == '1.4.0#600d56...416ef0f5e51ff'
E       
E       - 1.4.0#600d56c3da21eebac91416ef0f5e51ff
E       + 1.4.1#72615e3ac78acae253ce195d0045a800

tests/test_rpkgs.py:42: AssertionError
-------------------------------------------------------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------------------------------------------------------
2025-11-10 13:47:06 [info     ] updated                        [nvchecker.core] name=xml2 old_version=None revision=None url=None version=1.4.1#72615e3ac78acae253ce195d0045a800
_____________________________________________________________________________________________________________________________________ test_bioc ______________________________________________________________________________________________________________________________________

get_version = <function get_version.<locals>.__call__ at 0x7f74108254e0>

    async def test_bioc(get_version):
>     assert await get_version('BiocVersion', {
        'source': 'rpkgs',
        'pkgname': 'BiocVersion',
        'repo': 'bioc',
      }) == '3.21.1'
E     AssertionError: assert '3.22.0' == '3.21.1'
E       
E       - 3.21.1
E       + 3.22.0

tests/test_rpkgs.py:50: AssertionError
-------------------------------------------------------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------------------------------------------------------
2025-11-10 13:47:07 [info     ] updated                        [nvchecker.core] name=BiocVersion old_version=None revision=None url=None version=3.22.0
_____________________________________________________________________________________________________________________________ test_bioc_data_annotation ______________________________________________________________________________________________________________________________

get_version = <function get_version.<locals>.__call__ at 0x7f74108254e0>

    async def test_bioc_data_annotation(get_version):
>     assert await get_version('GO.db', {
        'source': 'rpkgs',
        'pkgname': 'GO.db',
        'repo': 'bioc-data-annotation',
      }) == '3.21.0'
E     AssertionError: assert '3.22.0' == '3.21.0'
E       
E       - 3.21.0
E       ?    ^
E       + 3.22.0
E       ?    ^

tests/test_rpkgs.py:57: AssertionError
-------------------------------------------------------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------------------------------------------------------
2025-11-10 13:47:09 [info     ] updated                        [nvchecker.core] name=GO.db old_version=None revision=None url=None version=3.22.0
_____________________________________________________________________________________________________________________________ test_bioc_data_experiment ______________________________________________________________________________________________________________________________

get_version = <function get_version.<locals>.__call__ at 0x7f74108254e0>

    async def test_bioc_data_experiment(get_version):
>     assert await get_version('ALL', {
        'source': 'rpkgs',
        'pkgname': 'ALL',
        'repo': 'bioc-data-experiment',
      }) == '1.50.0'
E     AssertionError: assert '1.52.0' == '1.50.0'
E       
E       - 1.50.0
E       ?    ^
E       + 1.52.0
E       ?    ^

tests/test_rpkgs.py:64: AssertionError
-------------------------------------------------------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------------------------------------------------------
2025-11-10 13:47:10 [info     ] updated                        [nvchecker.core] name=ALL old_version=None revision=None url=None version=1.52.0
============================================================================================================================== short test summary info ===============================================================================================================================
FAILED tests/test_rpkgs.py::test_cran - AssertionError: assert '1.4.1#72615e...e195d0045a800' == '1.4.0#600d56...416ef0f5e51ff'
FAILED tests/test_rpkgs.py::test_bioc - AssertionError: assert '3.22.0' == '3.21.1'
FAILED tests/test_rpkgs.py::test_bioc_data_annotation - AssertionError: assert '3.22.0' == '3.21.0'
FAILED tests/test_rpkgs.py::test_bioc_data_experiment - AssertionError: assert '1.52.0' == '1.50.0'
============================================================================================================================ 4 failed, 20 passed in 9.42s ============================================================================================================================
==> ERROR: A failure occurred in check().
    Aborting...
```