### PR TITLE
update tests

### DIFF
--- a/tests/test_rpkgs.py
+++ b/tests/test_rpkgs.py
@@ -44,7 +44,7 @@ async def test_cran(get_version):
     'pkgname': 'xml2',
     'repo': 'cran',
     'md5': True,
-  }) == '1.4.1#72615e3ac78acae253ce195d0045a800'
+  }) == '1.5.0#d8291d4edf45b9b802dc67d97bb20c7a'
 
 async def test_bioc(get_version):
   assert await get_version('BiocVersion', {


### PR DESCRIPTION
fix:

```
#13 60.99 ==> Starting check()...
#13 61.52 ============================= test session starts ==============================
#13 61.52 platform linux -- Python 3.13.7, pytest-8.4.2, pluggy-1.6.0
#13 61.52 rootdir: /pkgs/lilac-git/src/lilac
#13 61.52 configfile: pytest.ini
#13 61.52 plugins: anyio-4.11.0, asyncio-0.26.0
#13 61.52 asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=session, asyncio_default_test_loop_scope=function
#13 61.52 collected 24 items
#13 61.52 
#13 61.52 tests/test_api.py .............                                          [ 54%]
#13 61.53 tests/test_dependency_resolution.py .                                    [ 58%]
#13 61.54 tests/test_lilaclib.py .....                                             [ 79%]
#13 61.55 tests/test_rpkgs.py F....                                                [100%]
#13 63.07 
#13 63.07 =================================== FAILURES ===================================
#13 63.07 __________________________________ test_cran ___________________________________
#13 63.07 
#13 63.07 get_version = <function get_version.<locals>.__call__ at 0x7f3da647a5c0>
#13 63.07 
#13 63.07     async def test_cran(get_version):
#13 63.07 >     assert await get_version('xml2', {
#13 63.07         'source': 'rpkgs',
#13 63.07         'pkgname': 'xml2',
#13 63.07         'repo': 'cran',
#13 63.07         'md5': True,
#13 63.07       }) == '1.4.1#72615e3ac78acae253ce195d0045a800'
#13 63.07 E     AssertionError: assert '1.5.0#d8291d...c67d97bb20c7a' == '1.4.1#72615e...e195d0045a800'
#13 63.07 E       
#13 63.07 E       - 1.4.1#72615e3ac78acae253ce195d0045a800
#13 63.07 E       + 1.5.0#d8291d4edf45b9b802dc67d97bb20c7a
#13 63.07 
#13 63.07 tests/test_rpkgs.py:42: AssertionError
#13 63.07 ----------------------------- Captured stdout call -----------------------------
#13 63.07 2025-11-24 01:08:25 [info     ] updated                        [nvchecker.core] name=xml2 old_version=None revision=None url=None version=1.5.0#d8291d4edf45b9b802dc67d97bb20c7a
#13 63.07 =========================== short test summary info ============================
#13 63.07 FAILED tests/test_rpkgs.py::test_cran - AssertionError: assert '1.5.0#d8291d....
#13 63.07 ========================= 1 failed, 23 passed in 1.75s =========================
#13 63.12 ==> ERROR: A failure occurred in check().
#13 63.12     Aborting...
```