### PR TITLE
fix: resolve symlinks before calculating relative dependency paths

### DIFF
--- a/lilac2/building.py
+++ b/lilac2/building.py
@@ -147,7 +147,9 @@ def resolve_depends(repo: Optional[Repo], depends: Iterable[Dependency]) -> list
         continue
       need_build_first.add(x.pkgname)
     else:
-      depend_packages.append(f'../{p.relative_to(cwd)}')
+      # cwd is a physical path, resolve symlinks to prevent relative_to() error
+      p_real = p.resolve()
+      depend_packages.append(f'../{p_real.relative_to(cwd)}')
 
   if need_build_first:
     raise MissingDependencies(need_build_first)


### PR DESCRIPTION
`os.getcwd()` returns a physical path with symlinks resolved, while `Dependency.resolve()` returns a logical path. This 
mismatch causes `pathlib.Path.relative_to()` to raise a `ValueError` when the project is located inside a symlinked directory (e.g., `/home/lilac` -> `/mnt/Storage/lilac`).

This commit explicitly resolves both `cwd` and the dependency package path to their real physical paths before computing their relative location, ensuring `relative_to()` works reliably.

log:
```
[2026-05-07 22:55:19 +0800] build (version None) finished in 0s with result: <BuildResult.failed: ValueError("'/home/lilac/lilac/archoream/patool/patool-4.0.4-1-any.pkg.tar.zst' is not in the subpath of '/mnt/Storage/lilac/lilac/archoream'"); rusage=None>
```